### PR TITLE
Use mask as reference to define target CRS for downloaded imagery

### DIFF
--- a/src/ftw_dataset_tools/api/imagery/image_download.py
+++ b/src/ftw_dataset_tools/api/imagery/image_download.py
@@ -198,16 +198,21 @@ def read_single_band(
     target_height: int,
 ) -> tuple[str, np.ndarray]:
     """Read one band reprojected to the target grid."""
-    resampling = Resampling.nearest if band_name in {"scl", "cloud", "snow"} else Resampling.bilinear
+    resampling = (
+        Resampling.nearest if band_name in {"scl", "cloud", "snow"} else Resampling.bilinear
+    )
 
-    with rasterio.open(href) as source_dataset, WarpedVRT(
-        source_dataset,
-        crs=target_crs,
-        transform=target_transform,
-        width=target_width,
-        height=target_height,
-        resampling=resampling,
-    ) as warped_dataset:
+    with (
+        rasterio.open(href) as source_dataset,
+        WarpedVRT(
+            source_dataset,
+            crs=target_crs,
+            transform=target_transform,
+            width=target_width,
+            height=target_height,
+            resampling=resampling,
+        ) as warped_dataset,
+    ):
         data = warped_dataset.read(1)
 
     return band_name, data
@@ -239,7 +244,10 @@ def validate_alignment(output_path: Path, reference_grid: Path | None) -> str | 
         return None
 
     try:
-        with rasterio.open(output_path) as output_dataset, rasterio.open(reference_grid) as reference_dataset:
+        with (
+            rasterio.open(output_path) as output_dataset,
+            rasterio.open(reference_grid) as reference_dataset,
+        ):
             if (
                 output_dataset.crs != reference_dataset.crs
                 or output_dataset.transform != reference_dataset.transform

--- a/src/ftw_dataset_tools/api/imagery/image_download.py
+++ b/src/ftw_dataset_tools/api/imagery/image_download.py
@@ -202,6 +202,22 @@ def download_and_clip_scene(
     else:
         # Fallback grid in EPSG:4326 using the requested metric resolution
         # approximated to degrees at chip latitude.
+        if resolution <= 0:
+            return DownloadResult(
+                output_path=output_path,
+                scene_id=scene.id,
+                season=scene.season,
+                bands=bands,
+                width=0,
+                height=0,
+                crs="",
+                success=False,
+                error=(
+                    "Invalid resolution for fallback grid construction: "
+                    f"{resolution}. Resolution must be > 0 when no reference mask grid is found."
+                ),
+            )
+
         lat_center = (miny + maxy) / 2
         meters_per_degree_lon = 111320 * np.cos(np.radians(lat_center))
         meters_per_degree_lat = 111320

--- a/src/ftw_dataset_tools/api/imagery/image_download.py
+++ b/src/ftw_dataset_tools/api/imagery/image_download.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+    from affine import Affine
+
     from ftw_dataset_tools.api.imagery.scene_selection import SelectedScene
 
 __all__ = [
@@ -108,6 +110,151 @@ def find_reference_mask_for_output(output_path: Path) -> Path | None:
     return None
 
 
+def compute_target_grid(
+    bbox: tuple[float, float, float, float],
+    output_path: Path,
+    resolution: float,
+    reference_raster: Path | None,
+    on_progress: Callable[[str], None] | None = None,
+) -> tuple[tuple[CRS, Affine, int, int, Path | None] | None, str | None]:
+    """Compute output grid from reference mask or bbox+resolution fallback."""
+
+    def log(msg: str) -> None:
+        if on_progress:
+            on_progress(msg)
+
+    minx, miny, maxx, maxy = bbox
+    reference_grid = reference_raster or find_reference_mask_for_output(output_path)
+
+    if reference_grid is not None:
+        try:
+            with rasterio.open(reference_grid) as reference_dataset:
+                target_crs = reference_dataset.crs
+                target_transform = reference_dataset.transform
+                target_width = reference_dataset.width
+                target_height = reference_dataset.height
+                if target_crs is None:
+                    raise ValueError("Reference raster has no CRS")
+
+            log(
+                f"Grid: source=reference_mask path={reference_grid.name} "
+                f"crs={target_crs} width={target_width} height={target_height}"
+            )
+            log(f"Grid: using reference transform={target_transform}")
+            log(
+                f"Grid: requested resolution={resolution}m ignored because "
+                "reference mask defines output grid"
+            )
+            log(
+                f"Using reference mask grid: {reference_grid.name} "
+                f"({target_width}x{target_height}, {target_crs})"
+            )
+
+            return (
+                (target_crs, target_transform, target_width, target_height, reference_grid),
+                None,
+            )
+        except Exception as error:
+            return None, f"Failed to use reference raster {reference_grid}: {error}"
+
+    if resolution <= 0:
+        return (
+            None,
+            "Invalid resolution for fallback grid construction: "
+            f"{resolution}. Resolution must be > 0 when no reference mask grid is found.",
+        )
+
+    lat_center = (miny + maxy) / 2
+    meters_per_degree_lon = 111320 * np.cos(np.radians(lat_center))
+    meters_per_degree_lat = 111320
+
+    width_meters = (maxx - minx) * meters_per_degree_lon
+    height_meters = (maxy - miny) * meters_per_degree_lat
+
+    target_width = max(1, int(width_meters / resolution))
+    target_height = max(1, int(height_meters / resolution))
+    target_crs = CRS.from_epsg(4326)
+    target_transform = transform_from_bounds(minx, miny, maxx, maxy, target_width, target_height)
+
+    log(
+        f"Grid: source=fallback_bbox_resolution bbox=({minx:.6f}, {miny:.6f}, "
+        f"{maxx:.6f}, {maxy:.6f}) resolution_m={resolution}"
+    )
+    log(
+        f"Grid: computed crs={target_crs} width={target_width} "
+        f"height={target_height} transform={target_transform}"
+    )
+    log(f"No reference mask found, using EPSG:4326 fallback grid: {target_width}x{target_height}")
+
+    return (target_crs, target_transform, target_width, target_height, None), None
+
+
+def read_single_band(
+    band_name: str,
+    href: str,
+    target_crs: CRS,
+    target_transform: Affine,
+    target_width: int,
+    target_height: int,
+) -> tuple[str, np.ndarray]:
+    """Read one band reprojected to the target grid."""
+    resampling = Resampling.nearest if band_name in {"scl", "cloud", "snow"} else Resampling.bilinear
+
+    with rasterio.open(href) as source_dataset, WarpedVRT(
+        source_dataset,
+        crs=target_crs,
+        transform=target_transform,
+        width=target_width,
+        height=target_height,
+        resampling=resampling,
+    ) as warped_dataset:
+        data = warped_dataset.read(1)
+
+    return band_name, data
+
+
+def write_cog(
+    output_path: Path,
+    stacked: np.ndarray,
+    found_bands: list[str],
+    profile: dict,
+) -> str | None:
+    """Write stacked imagery as a COG and set band descriptions."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with rasterio.open(output_path, "w", **profile) as destination_dataset:
+            destination_dataset.write(stacked)
+            for band_index, band_name in enumerate(found_bands, start=1):
+                destination_dataset.set_band_description(band_index, band_name)
+    except Exception as error:
+        return f"Failed to write output: {error}"
+
+    return None
+
+
+def validate_alignment(output_path: Path, reference_grid: Path | None) -> str | None:
+    """Validate output alignment against reference mask; cleanup output on failure."""
+    if reference_grid is None:
+        return None
+
+    try:
+        with rasterio.open(output_path) as output_dataset, rasterio.open(reference_grid) as reference_dataset:
+            if (
+                output_dataset.crs != reference_dataset.crs
+                or output_dataset.transform != reference_dataset.transform
+                or output_dataset.width != reference_dataset.width
+                or output_dataset.height != reference_dataset.height
+            ):
+                output_path.unlink(missing_ok=True)
+                return f"Output image does not match reference mask grid ({reference_grid.name})"
+    except Exception as error:
+        output_path.unlink(missing_ok=True)
+        return f"Failed to validate output alignment: {error}"
+
+    return None
+
+
 def download_and_clip_scene(
     scene: SelectedScene,
     bbox: tuple[float, float, float, float],
@@ -161,109 +308,30 @@ def download_and_clip_scene(
     found_bands = list(band_hrefs.keys())
     log(f"Found {len(found_bands)} bands: {found_bands}")
 
-    minx, miny, maxx, maxy = bbox
+    target_grid, target_grid_error = compute_target_grid(
+        bbox=bbox,
+        output_path=output_path,
+        resolution=resolution,
+        reference_raster=reference_raster,
+        on_progress=on_progress,
+    )
 
-    reference_grid = reference_raster or find_reference_mask_for_output(output_path)
-
-    if reference_grid is not None:
-        try:
-            with rasterio.open(reference_grid) as ref:
-                target_crs = ref.crs
-                target_transform = ref.transform
-                target_width = ref.width
-                target_height = ref.height
-                if target_crs is None:
-                    raise ValueError("Reference raster has no CRS")
-            log(
-                f"Grid: source=reference_mask path={reference_grid.name} "
-                f"crs={target_crs} width={target_width} height={target_height}"
-            )
-            log(f"Grid: using reference transform={target_transform}")
-            log(
-                f"Grid: requested resolution={resolution}m ignored because "
-                "reference mask defines output grid"
-            )
-            log(
-                f"Using reference mask grid: {reference_grid.name} "
-                f"({target_width}x{target_height}, {target_crs})"
-            )
-        except Exception as e:
-            return DownloadResult(
-                output_path=output_path,
-                scene_id=scene.id,
-                season=scene.season,
-                bands=bands,
-                width=0,
-                height=0,
-                crs="",
-                success=False,
-                error=f"Failed to use reference raster {reference_grid}: {e}",
-            )
-    else:
-        # Fallback grid in EPSG:4326 using the requested metric resolution
-        # approximated to degrees at chip latitude.
-        if resolution <= 0:
-            return DownloadResult(
-                output_path=output_path,
-                scene_id=scene.id,
-                season=scene.season,
-                bands=bands,
-                width=0,
-                height=0,
-                crs="",
-                success=False,
-                error=(
-                    "Invalid resolution for fallback grid construction: "
-                    f"{resolution}. Resolution must be > 0 when no reference mask grid is found."
-                ),
-            )
-
-        lat_center = (miny + maxy) / 2
-        meters_per_degree_lon = 111320 * np.cos(np.radians(lat_center))
-        meters_per_degree_lat = 111320
-
-        width_meters = (maxx - minx) * meters_per_degree_lon
-        height_meters = (maxy - miny) * meters_per_degree_lat
-
-        target_width = max(1, int(width_meters / resolution))
-        target_height = max(1, int(height_meters / resolution))
-        target_crs = CRS.from_epsg(4326)
-        target_transform = transform_from_bounds(
-            minx, miny, maxx, maxy, target_width, target_height
+    if target_grid_error is not None or target_grid is None:
+        return DownloadResult(
+            output_path=output_path,
+            scene_id=scene.id,
+            season=scene.season,
+            bands=bands,
+            width=0,
+            height=0,
+            crs="",
+            success=False,
+            error=target_grid_error,
         )
-        log(
-            f"Grid: source=fallback_bbox_resolution bbox=({minx:.6f}, {miny:.6f}, "
-            f"{maxx:.6f}, {maxy:.6f}) resolution_m={resolution}"
-        )
-        log(
-            f"Grid: computed crs={target_crs} width={target_width} "
-            f"height={target_height} transform={target_transform}"
-        )
-        log(
-            f"No reference mask found, using EPSG:4326 fallback grid: "
-            f"{target_width}x{target_height}"
-        )
+
+    target_crs, target_transform, target_width, target_height, reference_grid = target_grid
 
     log(f"Target dimensions: {target_width}x{target_height} pixels")
-
-    def read_single_band(band_name: str, href: str) -> tuple[str, np.ndarray]:
-        """Read a single band projected to the target grid."""
-        # Use nearest neighbor for categorical/probability layers.
-        resampling = (
-            Resampling.nearest if band_name in {"scl", "cloud", "snow"} else Resampling.bilinear
-        )
-
-        with rasterio.open(href) as src:
-            with WarpedVRT(
-                src,
-                crs=target_crs,
-                transform=target_transform,
-                width=target_width,
-                height=target_height,
-                resampling=resampling,
-            ) as vrt:
-                data = vrt.read(1)
-            return band_name, data
 
     # Read bands in parallel for faster network throughput
     log(f"Reading {len(found_bands)} bands in parallel...")
@@ -273,7 +341,15 @@ def download_and_clip_scene(
 
     with ThreadPoolExecutor(max_workers=min(4, len(found_bands))) as executor:
         futures = {
-            executor.submit(read_single_band, band_name, href): band_name
+            executor.submit(
+                read_single_band,
+                band_name,
+                href,
+                target_crs,
+                target_transform,
+                target_width,
+                target_height,
+            ): band_name
             for band_name, href in band_hrefs.items()
         }
 
@@ -310,9 +386,6 @@ def download_and_clip_scene(
     stacked = np.stack(band_data, axis=0)
     log(f"Stacked shape: {stacked.shape}")
 
-    # Write output as COG
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-
     profile = {
         "driver": "COG",
         "dtype": stacked.dtype,
@@ -326,13 +399,8 @@ def download_and_clip_scene(
 
     log(f"Writing to {output_path}...")
 
-    try:
-        with rasterio.open(output_path, "w", **profile) as dst:
-            dst.write(stacked)
-            # Add band descriptions
-            for i, band_name in enumerate(found_bands, start=1):
-                dst.set_band_description(i, band_name)
-    except Exception as e:
+    write_error = write_cog(output_path, stacked, found_bands, profile)
+    if write_error is not None:
         return DownloadResult(
             output_path=output_path,
             scene_id=scene.id,
@@ -342,48 +410,24 @@ def download_and_clip_scene(
             height=0,
             crs="",
             success=False,
-            error=f"Failed to write output: {e}",
+            error=write_error,
         )
 
     log(f"Successfully wrote {output_path}")
 
-    if reference_grid is not None:
-        try:
-            with rasterio.open(output_path) as out_ds, rasterio.open(reference_grid) as ref_ds:
-                if (
-                    out_ds.crs != ref_ds.crs
-                    or out_ds.transform != ref_ds.transform
-                    or out_ds.width != ref_ds.width
-                    or out_ds.height != ref_ds.height
-                ):
-                    output_path.unlink(missing_ok=True)
-                    return DownloadResult(
-                        output_path=output_path,
-                        scene_id=scene.id,
-                        season=scene.season,
-                        bands=bands,
-                        width=0,
-                        height=0,
-                        crs="",
-                        success=False,
-                        error=(
-                            "Output image does not match reference mask grid "
-                            f"({reference_grid.name})"
-                        ),
-                    )
-        except Exception as e:
-            output_path.unlink(missing_ok=True)
-            return DownloadResult(
-                output_path=output_path,
-                scene_id=scene.id,
-                season=scene.season,
-                bands=bands,
-                width=0,
-                height=0,
-                crs="",
-                success=False,
-                error=f"Failed to validate output alignment: {e}",
-            )
+    alignment_error = validate_alignment(output_path, reference_grid)
+    if alignment_error is not None:
+        return DownloadResult(
+            output_path=output_path,
+            scene_id=scene.id,
+            season=scene.season,
+            bands=bands,
+            width=0,
+            height=0,
+            crs="",
+            success=False,
+            error=alignment_error,
+        )
 
     return DownloadResult(
         output_path=output_path,

--- a/src/ftw_dataset_tools/api/imagery/image_download.py
+++ b/src/ftw_dataset_tools/api/imagery/image_download.py
@@ -11,8 +11,9 @@ import numpy as np
 import pystac
 import rasterio
 from rasterio.crs import CRS
-from rasterio.warp import Resampling, calculate_default_transform, reproject
-from rasterio.windows import from_bounds
+from rasterio.transform import from_bounds as transform_from_bounds
+from rasterio.vrt import WarpedVRT
+from rasterio.warp import Resampling
 
 from ftw_dataset_tools.api.imagery.settings import BANDS_OF_INTEREST
 from ftw_dataset_tools.api.imagery.thumbnails import (
@@ -32,6 +33,7 @@ if TYPE_CHECKING:
 __all__ = [
     "DownloadResult",
     "download_and_clip_scene",
+    "find_reference_mask_for_output",
     "process_downloaded_scene",
 ]
 
@@ -73,57 +75,37 @@ def _get_band_hrefs(
     return hrefs
 
 
-def _read_band_windowed(
-    href: str,
-    bbox: tuple[float, float, float, float],
-    target_crs: CRS,
-    target_width: int,
-    target_height: int,
-) -> np.ndarray:
-    """
-    Read a band from a COG, clipping to bbox and reprojecting if needed.
+def find_reference_mask_for_output(output_path: Path) -> Path | None:
+    """Find a co-located mask raster to use as reference grid for imagery.
+
+    Prefers semantic 3-class masks, then semantic 2-class, then instance masks.
 
     Args:
-        href: URL or path to the COG
-        bbox: Target bounding box (minx, miny, maxx, maxy) in target_crs
-        target_crs: Target CRS
-        target_width: Target width in pixels
-        target_height: Target height in pixels
+        output_path: Target imagery output path (e.g. ``chip_001_2024_planting_image_s2.tif``)
 
     Returns:
-        numpy array with band data
+        Path to reference mask if available, otherwise ``None``.
     """
-    minx, miny, maxx, maxy = bbox
+    stem = output_path.stem
 
-    with rasterio.open(href) as src:
-        # Check if we need to reproject
-        if src.crs != target_crs:
-            # Calculate transform for target
-            transform, width, height = calculate_default_transform(
-                src.crs,
-                target_crs,
-                target_width,
-                target_height,
-                *bbox,
-            )
+    if stem.endswith("_planting_image_s2"):
+        base_id = stem.removesuffix("_planting_image_s2")
+    elif stem.endswith("_harvest_image_s2"):
+        base_id = stem.removesuffix("_harvest_image_s2")
+    else:
+        return None
 
-            # Read and reproject
-            data = np.empty((height, width), dtype=src.dtypes[0])
-            reproject(
-                source=rasterio.band(src, 1),
-                destination=data,
-                src_transform=src.transform,
-                src_crs=src.crs,
-                dst_transform=transform,
-                dst_crs=target_crs,
-                resampling=Resampling.bilinear,
-            )
-            return data
-        else:
-            # Read windowed data directly
-            window = from_bounds(minx, miny, maxx, maxy, src.transform)
-            data = src.read(1, window=window, out_shape=(target_height, target_width))
-            return data
+    candidates = [
+        output_path.parent / f"{base_id}_semantic_3_class.tif",
+        output_path.parent / f"{base_id}_semantic_2_class.tif",
+        output_path.parent / f"{base_id}_instance.tif",
+    ]
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    return None
 
 
 def download_and_clip_scene(
@@ -132,6 +114,7 @@ def download_and_clip_scene(
     output_path: Path,
     bands: list[str] | None = None,
     resolution: float = 10.0,
+    reference_raster: Path | None = None,
     on_progress: Callable[[str], None] | None = None,
 ) -> DownloadResult:
     """
@@ -143,6 +126,9 @@ def download_and_clip_scene(
         output_path: Path for output GeoTIFF
         bands: Bands to download (default: red, green, blue, nir)
         resolution: Target resolution in meters (default: 10.0)
+        reference_raster: Optional mask raster path used as exact output grid
+            reference (CRS, transform, width, height). If not provided, the
+            function auto-detects a co-located mask from ``output_path``.
         on_progress: Optional callback for progress messages
 
     Returns:
@@ -177,59 +163,90 @@ def download_and_clip_scene(
 
     minx, miny, maxx, maxy = bbox
 
-    # Calculate target dimensions based on resolution
-    # Approximate degrees to meters conversion at the equator
-    # For more accuracy, this should consider latitude
-    lat_center = (miny + maxy) / 2
-    meters_per_degree_lon = 111320 * np.cos(np.radians(lat_center))
-    meters_per_degree_lat = 111320
+    reference_grid = reference_raster or find_reference_mask_for_output(output_path)
 
-    width_meters = (maxx - minx) * meters_per_degree_lon
-    height_meters = (maxy - miny) * meters_per_degree_lat
+    if reference_grid is not None:
+        try:
+            with rasterio.open(reference_grid) as ref:
+                target_crs = ref.crs
+                target_transform = ref.transform
+                target_width = ref.width
+                target_height = ref.height
+                if target_crs is None:
+                    raise ValueError("Reference raster has no CRS")
+            log(
+                f"Grid: source=reference_mask path={reference_grid.name} "
+                f"crs={target_crs} width={target_width} height={target_height}"
+            )
+            log(f"Grid: using reference transform={target_transform}")
+            log(
+                f"Grid: requested resolution={resolution}m ignored because "
+                "reference mask defines output grid"
+            )
+            log(
+                f"Using reference mask grid: {reference_grid.name} "
+                f"({target_width}x{target_height}, {target_crs})"
+            )
+        except Exception as e:
+            return DownloadResult(
+                output_path=output_path,
+                scene_id=scene.id,
+                season=scene.season,
+                bands=bands,
+                width=0,
+                height=0,
+                crs="",
+                success=False,
+                error=f"Failed to use reference raster {reference_grid}: {e}",
+            )
+    else:
+        # Fallback grid in EPSG:4326 using the requested metric resolution
+        # approximated to degrees at chip latitude.
+        lat_center = (miny + maxy) / 2
+        meters_per_degree_lon = 111320 * np.cos(np.radians(lat_center))
+        meters_per_degree_lat = 111320
 
-    target_width = max(1, int(width_meters / resolution))
-    target_height = max(1, int(height_meters / resolution))
+        width_meters = (maxx - minx) * meters_per_degree_lon
+        height_meters = (maxy - miny) * meters_per_degree_lat
+
+        target_width = max(1, int(width_meters / resolution))
+        target_height = max(1, int(height_meters / resolution))
+        target_crs = CRS.from_epsg(4326)
+        target_transform = transform_from_bounds(
+            minx, miny, maxx, maxy, target_width, target_height
+        )
+        log(
+            f"Grid: source=fallback_bbox_resolution bbox=({minx:.6f}, {miny:.6f}, "
+            f"{maxx:.6f}, {maxy:.6f}) resolution_m={resolution}"
+        )
+        log(
+            f"Grid: computed crs={target_crs} width={target_width} "
+            f"height={target_height} transform={target_transform}"
+        )
+        log(
+            f"No reference mask found, using EPSG:4326 fallback grid: "
+            f"{target_width}x{target_height}"
+        )
 
     log(f"Target dimensions: {target_width}x{target_height} pixels")
 
-    # Use UTM CRS for the output (based on center of bbox)
-    # For simplicity, we'll use the CRS of the first band
-    first_href = next(iter(band_hrefs.values()))
-
-    try:
-        with rasterio.open(first_href) as src:
-            source_crs = src.crs
-    except Exception as e:
-        return DownloadResult(
-            output_path=output_path,
-            scene_id=scene.id,
-            season=scene.season,
-            bands=bands,
-            width=0,
-            height=0,
-            crs="",
-            success=False,
-            error=f"Failed to open source imagery: {e}",
+    def read_single_band(band_name: str, href: str) -> tuple[str, np.ndarray]:
+        """Read a single band projected to the target grid."""
+        # Use nearest neighbor for categorical/probability layers.
+        resampling = (
+            Resampling.nearest if band_name in {"scl", "cloud", "snow"} else Resampling.bilinear
         )
 
-    # Transform bbox to source CRS once (used by all bands)
-    if source_crs != CRS.from_epsg(4326):
-        from rasterio.warp import transform_bounds
-
-        src_bbox = transform_bounds(CRS.from_epsg(4326), source_crs, minx, miny, maxx, maxy)
-    else:
-        src_bbox = bbox
-
-    def read_single_band(band_name: str, href: str) -> tuple[str, np.ndarray]:
-        """Read a single band from a COG."""
         with rasterio.open(href) as src:
-            window = from_bounds(*src_bbox, src.transform)
-            data = src.read(
-                1,
-                window=window,
-                out_shape=(target_height, target_width),
-                resampling=Resampling.bilinear,
-            )
+            with WarpedVRT(
+                src,
+                crs=target_crs,
+                transform=target_transform,
+                width=target_width,
+                height=target_height,
+                resampling=resampling,
+            ) as vrt:
+                data = vrt.read(1)
             return band_name, data
 
     # Read bands in parallel for faster network throughput
@@ -277,11 +294,6 @@ def download_and_clip_scene(
     stacked = np.stack(band_data, axis=0)
     log(f"Stacked shape: {stacked.shape}")
 
-    # Calculate transform for output (reuse src_bbox computed earlier)
-    from rasterio.transform import from_bounds as transform_from_bounds
-
-    out_transform = transform_from_bounds(*src_bbox, target_width, target_height)
-
     # Write output as COG
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -291,8 +303,8 @@ def download_and_clip_scene(
         "width": target_width,
         "height": target_height,
         "count": len(found_bands),
-        "crs": source_crs,
-        "transform": out_transform,
+        "crs": target_crs,
+        "transform": target_transform,
         "compress": "deflate",
     }
 
@@ -319,6 +331,44 @@ def download_and_clip_scene(
 
     log(f"Successfully wrote {output_path}")
 
+    if reference_grid is not None:
+        try:
+            with rasterio.open(output_path) as out_ds, rasterio.open(reference_grid) as ref_ds:
+                if (
+                    out_ds.crs != ref_ds.crs
+                    or out_ds.transform != ref_ds.transform
+                    or out_ds.width != ref_ds.width
+                    or out_ds.height != ref_ds.height
+                ):
+                    output_path.unlink(missing_ok=True)
+                    return DownloadResult(
+                        output_path=output_path,
+                        scene_id=scene.id,
+                        season=scene.season,
+                        bands=bands,
+                        width=0,
+                        height=0,
+                        crs="",
+                        success=False,
+                        error=(
+                            "Output image does not match reference mask grid "
+                            f"({reference_grid.name})"
+                        ),
+                    )
+        except Exception as e:
+            output_path.unlink(missing_ok=True)
+            return DownloadResult(
+                output_path=output_path,
+                scene_id=scene.id,
+                season=scene.season,
+                bands=bands,
+                width=0,
+                height=0,
+                crs="",
+                success=False,
+                error=f"Failed to validate output alignment: {e}",
+            )
+
     return DownloadResult(
         output_path=output_path,
         scene_id=scene.id,
@@ -326,7 +376,7 @@ def download_and_clip_scene(
         bands=found_bands,
         width=target_width,
         height=target_height,
-        crs=str(source_crs),
+        crs=str(target_crs),
         success=True,
     )
 

--- a/src/ftw_dataset_tools/commands/create_dataset.py
+++ b/src/ftw_dataset_tools/commands/create_dataset.py
@@ -69,7 +69,10 @@ from ftw_dataset_tools.api.stac import detect_datetime_column, get_year_from_dat
     type=float,
     default=10.0,
     show_default=True,
-    help="Pixel resolution in meters for masks.",
+    help=(
+        "Pixel resolution in meters for masks; also used as imagery fallback "
+        "when no reference mask grid is found."
+    ),
 )
 @click.option(
     "--workers",
@@ -604,6 +607,10 @@ def _run_image_download(
     band_list = list(bands)
     can_generate_thumbnail = has_rgb_bands(band_list)
 
+    def on_download_progress(msg: str) -> None:
+        if msg.startswith("Grid:"):
+            tqdm.write(f"  {msg}")
+
     with tqdm(
         total=len(child_items), desc="Downloading imagery", unit="scene", leave=False
     ) as pbar:
@@ -641,6 +648,7 @@ def _run_image_download(
                     output_path=output_path,
                     bands=band_list,
                     resolution=resolution,
+                    on_progress=on_download_progress,
                 )
 
                 if result.success:

--- a/src/ftw_dataset_tools/commands/download_images.py
+++ b/src/ftw_dataset_tools/commands/download_images.py
@@ -63,7 +63,10 @@ VALID_BANDS: tuple[str, ...] = (
     type=float,
     default=10.0,
     show_default=True,
-    help="Target resolution in meters.",
+    help=(
+        "Target resolution in meters when no reference mask grid is found. "
+        "If a co-located mask exists, its CRS/transform/size is used instead."
+    ),
 )
 @click.option(
     "--resume",
@@ -188,7 +191,8 @@ def download_images_cmd(
 
     # Progress callback
     def on_progress(msg: str) -> None:
-        pass  # Suppress individual band progress for cleaner output
+        if msg.startswith("Grid:"):
+            tqdm.write(f"  {msg}")
 
     # Process each child item
     with tqdm(total=len(child_items), desc="Downloading imagery", unit="scene") as pbar:

--- a/tests/test_api/test_imagery/test_image_download.py
+++ b/tests/test_api/test_imagery/test_image_download.py
@@ -3,11 +3,21 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
-from ftw_dataset_tools.api.imagery.image_download import find_reference_mask_for_output
+import numpy as np
+import rasterio
+from rasterio.transform import from_origin
+
+from ftw_dataset_tools.api.imagery.image_download import (
+    download_and_clip_scene,
+    find_reference_mask_for_output,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from ftw_dataset_tools.api.imagery.scene_selection import SelectedScene
 
 
 class TestFindReferenceMaskForOutput:
@@ -51,3 +61,207 @@ class TestFindReferenceMaskForOutput:
         found = find_reference_mask_for_output(output_path)
 
         assert found is None
+
+
+class TestDownloadAndClipScene:
+    """Tests for download_and_clip_scene validation behavior."""
+
+    @staticmethod
+    def _write_single_band_raster(
+        path: Path,
+        data: np.ndarray,
+        transform,
+        crs: str = "EPSG:4326",
+    ) -> None:
+        """Write a single-band test raster."""
+        with rasterio.open(
+            path,
+            "w",
+            driver="GTiff",
+            width=data.shape[1],
+            height=data.shape[0],
+            count=1,
+            dtype=str(data.dtype),
+            crs=crs,
+            transform=transform,
+        ) as dst:
+            dst.write(data, 1)
+
+    def test_uses_explicit_reference_raster_override_happy_path(
+        self,
+        tmp_path: Path,
+        mock_selected_scene: SelectedScene,
+    ) -> None:
+        """Uses explicit reference_raster override instead of auto-detected mask."""
+        output_path = tmp_path / "chip_001_2024_planting_image_s2.tif"
+
+        # Auto-detected mask candidate (should be ignored due to explicit override)
+        auto_mask = tmp_path / "chip_001_2024_semantic_3_class.tif"
+        self._write_single_band_raster(
+            auto_mask,
+            np.zeros((3, 4), dtype=np.uint8),
+            from_origin(10.0, 50.01, 0.0025, 0.0025),
+        )
+
+        explicit_reference = tmp_path / "explicit_reference.tif"
+        self._write_single_band_raster(
+            explicit_reference,
+            np.zeros((6, 7), dtype=np.uint8),
+            from_origin(10.0, 50.01, 0.0014285714285714286, 0.0016666666666666668),
+        )
+
+        source_path = tmp_path / "source_red.tif"
+        source_data = np.arange(100, dtype=np.uint16).reshape(10, 10)
+        self._write_single_band_raster(
+            source_path,
+            source_data,
+            from_origin(10.0, 50.01, 0.001, 0.001),
+        )
+
+        mock_selected_scene.item.assets["red"].href = str(source_path)
+
+        result = download_and_clip_scene(
+            scene=mock_selected_scene,
+            bbox=(10.0, 50.0, 10.01, 50.01),
+            output_path=output_path,
+            bands=["red"],
+            reference_raster=explicit_reference,
+            resolution=10.0,
+        )
+
+        assert result.success is True
+        assert result.width == 7
+        assert result.height == 6
+        assert result.crs == "EPSG:4326"
+
+        with rasterio.open(output_path) as output_ds:
+            assert output_ds.width == 7
+            assert output_ds.height == 6
+
+    def test_returns_structured_failure_for_nonexistent_reference_raster(
+        self,
+        tmp_path: Path,
+        mock_selected_scene: SelectedScene,
+    ) -> None:
+        """Returns DownloadResult failure when explicit reference_raster does not exist."""
+        output_path = tmp_path / "chip_001_2024_planting_image_s2.tif"
+        missing_reference = tmp_path / "missing_reference.tif"
+
+        result = download_and_clip_scene(
+            scene=mock_selected_scene,
+            bbox=(10.0, 50.0, 10.01, 50.01),
+            output_path=output_path,
+            bands=["red"],
+            reference_raster=missing_reference,
+            resolution=10.0,
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "Failed to use reference raster" in result.error
+
+    def test_validation_failure_cleans_up_output_file(
+        self,
+        tmp_path: Path,
+        mock_selected_scene: SelectedScene,
+    ) -> None:
+        """Removes output file and returns error when alignment validation fails."""
+        output_path = tmp_path / "chip_001_2024_planting_image_s2.tif"
+        reference_mask = tmp_path / "chip_001_2024_semantic_3_class.tif"
+        source_path = tmp_path / "source_red.tif"
+
+        self._write_single_band_raster(
+            reference_mask,
+            np.zeros((8, 8), dtype=np.uint8),
+            from_origin(10.0, 50.01, 0.00125, 0.00125),
+        )
+        self._write_single_band_raster(
+            source_path,
+            np.arange(100, dtype=np.uint16).reshape(10, 10),
+            from_origin(10.0, 50.01, 0.001, 0.001),
+        )
+
+        mock_selected_scene.item.assets["red"].href = str(source_path)
+
+        real_rasterio_open = rasterio.open
+        reference_open_calls = {"count": 0}
+
+        def open_with_validation_failure(path, *args, **kwargs):
+            mode = kwargs.get("mode") if "mode" in kwargs else (args[0] if args else "r")
+            path_str = str(path)
+            if path_str == str(reference_mask) and mode == "r":
+                reference_open_calls["count"] += 1
+                if reference_open_calls["count"] >= 2:
+                    raise RuntimeError("forced validation failure")
+            return real_rasterio_open(path, *args, **kwargs)
+
+        with patch("ftw_dataset_tools.api.imagery.image_download.rasterio.open") as mock_open:
+            mock_open.side_effect = open_with_validation_failure
+
+            result = download_and_clip_scene(
+                scene=mock_selected_scene,
+                bbox=(10.0, 50.0, 10.01, 50.01),
+                output_path=output_path,
+                bands=["red"],
+                resolution=10.0,
+            )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "Failed to validate output alignment" in result.error
+        assert output_path.exists() is False
+
+    def test_fails_for_non_positive_resolution_without_reference_mask(
+        self,
+        tmp_path: Path,
+        mock_selected_scene: SelectedScene,
+    ) -> None:
+        """Returns structured failure before any raster read for invalid fallback resolution."""
+        output_path = tmp_path / "chip_001_2024_planting_image_s2.tif"
+
+        with patch("ftw_dataset_tools.api.imagery.image_download.rasterio.open") as mock_open:
+            result = download_and_clip_scene(
+                scene=mock_selected_scene,
+                bbox=(10.0, 50.0, 10.01, 50.01),
+                output_path=output_path,
+                resolution=0.0,
+            )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "Resolution must be > 0" in result.error
+        assert mock_open.call_count == 0
+
+    def test_uses_reference_mask_even_with_non_positive_resolution(
+        self,
+        tmp_path: Path,
+        mock_selected_scene: SelectedScene,
+    ) -> None:
+        """Does not fail on non-positive resolution when reference grid is provided."""
+        output_path = tmp_path / "chip_001_2024_planting_image_s2.tif"
+        reference_mask = tmp_path / "chip_001_2024_semantic_3_class.tif"
+
+        mask_data = np.zeros((8, 8), dtype=np.uint8)
+        with rasterio.open(
+            reference_mask,
+            "w",
+            driver="GTiff",
+            width=8,
+            height=8,
+            count=1,
+            dtype="uint8",
+            crs="EPSG:4326",
+            transform=from_origin(10.0, 50.01, 0.00125, 0.00125),
+        ) as dst:
+            dst.write(mask_data, 1)
+
+        # We only validate that resolution guard is bypassed. Source reads may still fail
+        # due to remote mock assets, but not because of non-positive resolution.
+        result = download_and_clip_scene(
+            scene=mock_selected_scene,
+            bbox=(10.0, 50.0, 10.01, 50.01),
+            output_path=output_path,
+            resolution=0.0,
+        )
+
+        assert "Resolution must be > 0" not in (result.error or "")

--- a/tests/test_api/test_imagery/test_image_download.py
+++ b/tests/test_api/test_imagery/test_image_download.py
@@ -1,0 +1,53 @@
+"""Tests for image_download module helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ftw_dataset_tools.api.imagery.image_download import find_reference_mask_for_output
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestFindReferenceMaskForOutput:
+    """Tests for reference mask auto-detection."""
+
+    def test_prefers_semantic_3_class(self, tmp_path: Path) -> None:
+        """Picks semantic_3_class when multiple masks are available."""
+        output_path = tmp_path / "chip_001_2024_planting_image_s2.tif"
+        (tmp_path / "chip_001_2024_instance.tif").touch()
+        expected = tmp_path / "chip_001_2024_semantic_3_class.tif"
+        expected.touch()
+
+        found = find_reference_mask_for_output(output_path)
+
+        assert found == expected
+
+    def test_falls_back_to_semantic_2_class(self, tmp_path: Path) -> None:
+        """Falls back to semantic_2_class when semantic_3_class is missing."""
+        output_path = tmp_path / "chip_001_2024_harvest_image_s2.tif"
+        expected = tmp_path / "chip_001_2024_semantic_2_class.tif"
+        expected.touch()
+
+        found = find_reference_mask_for_output(output_path)
+
+        assert found == expected
+
+    def test_falls_back_to_instance(self, tmp_path: Path) -> None:
+        """Falls back to instance mask when semantic masks are missing."""
+        output_path = tmp_path / "chip_001_2024_planting_image_s2.tif"
+        expected = tmp_path / "chip_001_2024_instance.tif"
+        expected.touch()
+
+        found = find_reference_mask_for_output(output_path)
+
+        assert found == expected
+
+    def test_returns_none_when_not_matching_pattern(self, tmp_path: Path) -> None:
+        """Returns None for filenames that do not match imagery naming pattern."""
+        output_path = tmp_path / "custom_output.tif"
+
+        found = find_reference_mask_for_output(output_path)
+
+        assert found is None


### PR DESCRIPTION
The downloaded imagery was in the local UTM projection (e.g. EPSG:32xxx) but the masks were in EPSG:4326. This caused a mismatch between label and image pixels.

Updated the download-images code to look for a reference mask to match the CRS/transform to. If none found, it falls back on the user-specified --resolution flag. Added logging to make that clear. 

In the future, we may want to do something different if we have different mask resolutions, but I think this is the safest to make sure the input and label tifs match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for co-located reference mask-based grid alignment during image downloads
  * Enhanced progress feedback with grid determination messages during processing

* **Bug Fixes**
  * Added validation to verify downloaded image alignment against reference masks

* **Tests**
  * Comprehensive test coverage for image download and clipping utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->