### PR TITLE
Add config-driven workflow with ftwd run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,56 @@ uv sync --dev
 ftwd --help
 ```
 
+### run (config-driven workflow)
+
+Run the whole pipeline from a single YAML config file instead of a long chain of
+CLI flags. This keeps every setting in one place and records exactly what went
+into a dataset: a fully-resolved copy of the config (all defaults filled in, plus
+the `ftwd` version and a timestamp) is written to the output directory as
+`ftwd-config.resolved.yaml` and embedded in the STAC root catalog under the
+`ftw:config` field.
+
+```bash
+# Run the full pipeline from a config
+ftwd run config.yaml
+
+# Preview the resolved config and the stages that would run (no execution)
+ftwd run config.yaml --dry-run
+
+# List the pipeline stages in order
+ftwd run config.yaml --list-stages
+
+# Run or re-run a single stage (forced, even if disabled in the config)
+ftwd run config.yaml --only masks
+
+# Run from a stage to the end, or from the start through a stage
+ftwd run config.yaml --from select_images
+ftwd run config.yaml --through stac
+```
+
+Stages run in this order: `reproject`, `chips`, `splits`, `boundaries`, `masks`,
+`stac`, `select_images`, `download_images`. Intermediate outputs follow a fixed
+naming convention in the output directory, so individual stages can be re-run on
+their own as long as their inputs already exist.
+
+See [`examples/config.yaml`](examples/config.yaml) for a fully documented config.
+A minimal config:
+
+```yaml
+fields_file: austria_fields.parquet
+output_dir: ./austria-dataset
+name: austria
+year: 2023
+
+stages:
+  splits:
+    split_type: random-uniform
+  select_images:
+    enabled: true
+  download_images:
+    enabled: false
+```
+
 ### create-dataset
 
 Create a complete training dataset from a single fields file. This is the main command that orchestrates the entire pipeline.

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,0 +1,74 @@
+# Example config for the ftwd config-driven workflow.
+#
+# Run the full pipeline with:
+#     ftwd run examples/config.yaml
+#
+# Run or re-run individual stages with:
+#     ftwd run examples/config.yaml --only masks
+#     ftwd run examples/config.yaml --from select_images
+#     ftwd run examples/config.yaml --through stac
+#
+# Preview what would run without executing:
+#     ftwd run examples/config.yaml --dry-run
+#
+# A fully-resolved copy of this config (with all defaults filled in, plus the
+# ftwd version and a timestamp) is written to the output directory as
+# `ftwd-config.resolved.yaml` and embedded in the STAC catalog under `ftw:config`.
+
+# Config schema version (optional; informational).
+version: 1
+
+# Path to the input GeoParquet field boundaries.
+fields_file: austria_fields.parquet
+
+# Output directory. If omitted, defaults to "{input_stem}-dataset".
+output_dir: ./austria-dataset
+
+# Dataset name used in output filenames. If omitted, defaults to the input stem.
+name: austria
+
+# Calendar year for temporal extent. Optional if the fields file has a
+# determination_datetime column.
+year: 2023
+
+# If true, fail instead of auto-reprojecting non-EPSG:4326 input.
+skip_reproject: false
+
+stages:
+  chips:
+    # Minimum field-coverage percentage for a grid cell to be kept.
+    min_coverage: 0.01
+    # Drop chips on the outer border of the dataset (partial coverage).
+    drop_border_chips: false
+
+  splits:
+    # One of: block3x3, predefined, random-uniform.
+    split_type: random-uniform
+    # Train / val / test percentages (must sum to 100).
+    split_percents: [80, 10, 10]
+    random_seed: 42
+
+  masks:
+    # Any subset of: instance, semantic_2_class, semantic_3_class.
+    mask_types: [instance, semantic_2_class, semantic_3_class]
+    # Pixel resolution in meters.
+    resolution: 10.0
+    # Parallel workers (null = half of CPUs).
+    workers: null
+    # Presence-only labels: background class value becomes 3 instead of 0.
+    presence_only: false
+
+  select_images:
+    # Set to false to skip imagery selection entirely.
+    enabled: true
+    cloud_cover_chip: 2.0
+    nodata_max: 0.0
+    buffer_days: 14
+    num_buffer_expansions: 3
+    buffer_expansion_size: 14
+
+  download_images:
+    # Disabled by default; imagery selection creates STAC references only.
+    enabled: false
+    bands: [red, green, blue, nir]
+    resolution: 10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pillow>=10.0.0",
     "pystac>=1.10.0",
     "pystac-client>=0.7.0",
+    "pyyaml>=6.0",
     "rasterio>=1.3.0",
     "rustac[arrow]>=0.3.0",
     "shapely>=2.0.0",

--- a/src/ftw_dataset_tools/api/config.py
+++ b/src/ftw_dataset_tools/api/config.py
@@ -1,0 +1,324 @@
+"""Config-driven workflow schema and loading for FTW dataset creation.
+
+This module defines the YAML config schema for ``ftwd run`` as a set of
+dataclasses, plus helpers to load/validate a config file, fill in defaults, and
+produce a fully-resolved provenance record.
+
+The config is the single source of truth for a dataset build: every setting that
+the ``create-dataset`` pipeline accepts has a home here. Loading a config resolves
+all defaults so the resolved form can be written alongside the output for
+reproducibility.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, fields
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ftw_dataset_tools import __version__
+from ftw_dataset_tools.api import splits
+
+# Mask types that ``create-masks`` understands. Kept here so config validation
+# gives the same error the CLI does.
+VALID_MASK_TYPES = ("instance", "semantic_2_class", "semantic_3_class")
+
+# Current config schema version. Bump when the schema changes incompatibly.
+CONFIG_SCHEMA_VERSION = 1
+
+
+class ConfigError(ValueError):
+    """Raised when a config file is malformed or contains invalid values."""
+
+
+@dataclass
+class ChipsConfig:
+    """Settings for the chips stage (field coverage statistics)."""
+
+    min_coverage: float = 0.01
+    drop_border_chips: bool = False
+
+
+@dataclass
+class SplitsConfig:
+    """Settings for the train/val/test split stage."""
+
+    split_type: str | None = None
+    split_percents: tuple[int, int, int] = (80, 10, 10)
+    random_seed: int = 42
+
+
+@dataclass
+class MasksConfig:
+    """Settings for the raster mask stage."""
+
+    mask_types: list[str] = field(
+        default_factory=lambda: ["instance", "semantic_2_class", "semantic_3_class"]
+    )
+    resolution: float = 10.0
+    workers: int | None = None
+    presence_only: bool = False
+
+
+@dataclass
+class SelectImagesConfig:
+    """Settings for the imagery selection stage."""
+
+    enabled: bool = True
+    cloud_cover_chip: float = 2.0
+    nodata_max: float = 0.0
+    buffer_days: int = 14
+    num_buffer_expansions: int = 3
+    buffer_expansion_size: int = 14
+
+
+@dataclass
+class DownloadImagesConfig:
+    """Settings for the imagery download stage."""
+
+    enabled: bool = False
+    bands: list[str] = field(default_factory=lambda: ["red", "green", "blue", "nir"])
+    resolution: float = 10.0
+
+
+@dataclass
+class StagesConfig:
+    """Per-stage settings. Stages with no options (boundaries, stac) still run."""
+
+    chips: ChipsConfig = field(default_factory=ChipsConfig)
+    splits: SplitsConfig = field(default_factory=SplitsConfig)
+    masks: MasksConfig = field(default_factory=MasksConfig)
+    select_images: SelectImagesConfig = field(default_factory=SelectImagesConfig)
+    download_images: DownloadImagesConfig = field(default_factory=DownloadImagesConfig)
+
+
+@dataclass
+class DatasetConfig:
+    """Top-level config for a dataset build.
+
+    Attributes:
+        fields_file: Path to the input GeoParquet field boundaries.
+        output_dir: Output directory. If None, derived from the input stem.
+        name: Dataset name used in filenames. If None, derived from the input stem.
+        year: Calendar year for temporal extent (optional if the fields file has
+            a determination_datetime column).
+        skip_reproject: If True, fail instead of reprojecting non-4326 input.
+        stages: Per-stage settings.
+    """
+
+    fields_file: str
+    output_dir: str | None = None
+    name: str | None = None
+    year: int | None = None
+    skip_reproject: bool = False
+    stages: StagesConfig = field(default_factory=StagesConfig)
+
+    # ---- construction ---------------------------------------------------
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DatasetConfig:
+        """Build and validate a config from a plain dict (e.g. parsed YAML)."""
+        if not isinstance(data, dict):
+            raise ConfigError("Config root must be a mapping of keys to values.")
+
+        # Ignore a documented schema-version key if present.
+        data = {k: v for k, v in data.items() if k != "version"}
+
+        top_keys = {f.name for f in fields(cls)}
+        _reject_unknown(data, top_keys, context="config")
+
+        if "fields_file" not in data or data["fields_file"] is None:
+            raise ConfigError("Config must specify 'fields_file'.")
+
+        stages_data = data.get("stages") or {}
+        if not isinstance(stages_data, dict):
+            raise ConfigError("'stages' must be a mapping.")
+        stages = _build_stages(stages_data)
+
+        config = cls(
+            fields_file=str(data["fields_file"]),
+            output_dir=_opt_str(data.get("output_dir")),
+            name=_opt_str(data.get("name")),
+            year=data.get("year"),
+            skip_reproject=bool(data.get("skip_reproject", False)),
+            stages=stages,
+        )
+        config.validate()
+        return config
+
+    @classmethod
+    def from_kwargs(
+        cls,
+        *,
+        fields_file: str,
+        output_dir: str | None,
+        field_dataset: str | None,
+        split_type: str | None,
+        split_percents: tuple[int, int, int],
+        min_coverage: float,
+        resolution: float,
+        num_workers: int | None,
+        skip_reproject: bool,
+        year: int | None,
+        mask_types: list[str] | None,
+        presence_only: bool,
+        drop_border_chips: bool,
+    ) -> DatasetConfig:
+        """Build a config from ``create_dataset`` keyword arguments.
+
+        Lets the flag-driven ``create-dataset`` pipeline share the config-driven
+        orchestration. Imagery stages are disabled here because the
+        ``create-dataset`` API does not run imagery itself.
+        """
+        config = cls(
+            fields_file=str(fields_file),
+            output_dir=str(output_dir) if output_dir is not None else None,
+            name=field_dataset,
+            year=year,
+            skip_reproject=skip_reproject,
+            stages=StagesConfig(
+                chips=ChipsConfig(
+                    min_coverage=min_coverage,
+                    drop_border_chips=drop_border_chips,
+                ),
+                splits=SplitsConfig(split_type=split_type, split_percents=split_percents),
+                masks=MasksConfig(
+                    mask_types=list(mask_types)
+                    if mask_types is not None
+                    else list(VALID_MASK_TYPES),
+                    resolution=resolution,
+                    workers=num_workers,
+                    presence_only=presence_only,
+                ),
+                select_images=SelectImagesConfig(enabled=False),
+                download_images=DownloadImagesConfig(enabled=False),
+            ),
+        )
+        config.validate()
+        return config
+
+    # ---- validation -----------------------------------------------------
+
+    def validate(self) -> None:
+        """Validate values, raising ConfigError on the first problem found."""
+        split_type = self.stages.splits.split_type
+        if split_type is not None and split_type not in splits.SPLIT_TYPE_CHOICES:
+            raise ConfigError(
+                f"Invalid split_type '{split_type}'. "
+                f"Must be one of: {splits.SPLIT_TYPE_CHOICES_STR}."
+            )
+
+        try:
+            resolved = splits.validate_split_percents(self.stages.splits.split_percents)
+        except ValueError as err:
+            raise ConfigError(f"Invalid split_percents: {err}") from err
+        self.stages.splits.split_percents = resolved
+
+        for mask_type in self.stages.masks.mask_types:
+            if mask_type not in VALID_MASK_TYPES:
+                raise ConfigError(
+                    f"Invalid mask type '{mask_type}'. "
+                    f"Must be one of: {', '.join(VALID_MASK_TYPES)}."
+                )
+        if not self.stages.masks.mask_types:
+            raise ConfigError("masks.mask_types must list at least one mask type.")
+
+    # ---- provenance -----------------------------------------------------
+
+    def config_dict(self) -> dict[str, Any]:
+        """Return the config as a plain dict with all defaults resolved."""
+        data = asdict(self)
+        # asdict turns the split_percents tuple into a list; keep it a list for YAML.
+        data["stages"]["splits"]["split_percents"] = list(self.stages.splits.split_percents)
+        return data
+
+    def provenance_dict(self, generated_at: datetime | None = None) -> dict[str, Any]:
+        """Return a resolved provenance record for output and STAC embedding."""
+        stamp = generated_at or datetime.now(UTC)
+        return {
+            "ftwd_version": __version__,
+            "config_schema_version": CONFIG_SCHEMA_VERSION,
+            "generated_at": stamp.isoformat(),
+            "config": self.config_dict(),
+        }
+
+
+def load_config(path: str | Path) -> DatasetConfig:
+    """Load and validate a YAML config file into a DatasetConfig."""
+    config_path = Path(path)
+    if not config_path.exists():
+        raise ConfigError(f"Config file not found: {config_path}")
+
+    try:
+        raw = yaml.safe_load(config_path.read_text())
+    except yaml.YAMLError as err:
+        raise ConfigError(f"Could not parse YAML config {config_path}: {err}") from err
+
+    if raw is None:
+        raise ConfigError(f"Config file is empty: {config_path}")
+
+    return DatasetConfig.from_dict(raw)
+
+
+def write_provenance_file(
+    provenance: dict[str, Any],
+    output_dir: str | Path,
+    filename: str = "ftwd-config.resolved.yaml",
+) -> Path:
+    """Write a resolved provenance record (from :meth:`provenance_dict`) to disk."""
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / filename
+    out_path.write_text(yaml.safe_dump(provenance, sort_keys=False, default_flow_style=False))
+    return out_path
+
+
+# ---- internal helpers ---------------------------------------------------
+
+
+def _reject_unknown(data: dict[str, Any], known: set[str], context: str) -> None:
+    unknown = set(data) - known
+    if unknown:
+        raise ConfigError(
+            f"Unknown key(s) in {context}: {', '.join(sorted(unknown))}. "
+            f"Allowed keys: {', '.join(sorted(known))}."
+        )
+
+
+def _opt_str(value: Any) -> str | None:
+    return str(value) if value is not None else None
+
+
+_STAGE_TYPES: dict[str, type] = {
+    "chips": ChipsConfig,
+    "splits": SplitsConfig,
+    "masks": MasksConfig,
+    "select_images": SelectImagesConfig,
+    "download_images": DownloadImagesConfig,
+}
+
+
+def _build_stages(stages_data: dict[str, Any]) -> StagesConfig:
+    _reject_unknown(stages_data, set(_STAGE_TYPES), context="stages")
+    kwargs: dict[str, Any] = {}
+    for name, stage_type in _STAGE_TYPES.items():
+        section = stages_data.get(name)
+        if section is None:
+            continue
+        if not isinstance(section, dict):
+            raise ConfigError(f"stages.{name} must be a mapping.")
+        kwargs[name] = _build_stage(stage_type, section, name)
+    return StagesConfig(**kwargs)
+
+
+def _build_stage(stage_type: type, section: dict[str, Any], name: str) -> Any:
+    known = {f.name for f in fields(stage_type)}
+    _reject_unknown(section, known, context=f"stages.{name}")
+    value = stage_type(**section)
+    # Normalize split_percents (YAML lists) into a tuple.
+    if isinstance(value, SplitsConfig) and value.split_percents is not None:
+        value.split_percents = tuple(value.split_percents)  # type: ignore[assignment]
+    return value

--- a/src/ftw_dataset_tools/api/dataset.py
+++ b/src/ftw_dataset_tools/api/dataset.py
@@ -2,24 +2,15 @@
 
 from __future__ import annotations
 
-import shutil
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import TYPE_CHECKING
 
-import duckdb
-
-from ftw_dataset_tools.api import boundaries, field_stats, masks, splits, stac
-from ftw_dataset_tools.api.geo import (
-    detect_crs,
-    detect_geometry_column,
-    ensure_spatial_loaded,
-    reproject,
-)
-from ftw_dataset_tools.api.masks import MaskType, get_item_id
+from ftw_dataset_tools.api import boundaries, field_stats, masks, pipeline, splits, stac
+from ftw_dataset_tools.api.config import DatasetConfig
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
 
 
 @dataclass
@@ -101,231 +92,48 @@ def create_dataset(
         ValueError: If input CRS is not EPSG:4326 and skip_reproject is True
         ValueError: If year not provided and no determination_datetime column
     """
-    fields_path = Path(fields_file).resolve()
-    out_dir = Path(output_dir).resolve()
-
-    if not fields_path.exists():
-        raise FileNotFoundError(f"Fields file not found: {fields_path}")
-
-    # Default field_dataset to input filename stem
-    if field_dataset is None:
-        field_dataset = fields_path.stem
-
-    def log(msg: str) -> None:
-        if on_progress:
-            on_progress(msg)
-
-    log(f"Creating dataset '{field_dataset}' from {fields_path.name}")
-
-    if split_type is None:
-        raise ValueError("split_type is required and cannot be None")
-    if split_type not in splits.SPLIT_TYPE_CHOICES:
-        raise ValueError(f"split_type must be one of: {splits.SPLIT_TYPE_CHOICES_STR}")
-
-    # Validate at API layer to protect against invalid input from direct programmatic usage
-    # (CLI also validates for immediate user feedback, but API may be called directly)
-    split_percents = splits.validate_split_percents(split_percents)
-    log(f"Using split percents (train/val/test): {split_percents}")
-
-    # Early validation: Check temporal extent availability
-    # This avoids processing the entire dataset only to fail at STAC generation
-    log("Checking temporal extent availability...")
-    datetime_col = stac.detect_datetime_column(fields_path)
-    effective_year = year
-    if datetime_col:
-        log(f"Found '{datetime_col}' column for temporal extent")
-        # Extract year from datetime column for chip ID naming if not explicitly provided
-        if effective_year is None:
-            effective_year = stac.get_year_from_datetime_column(fields_path, datetime_col)
-            if effective_year:
-                log(f"Using year {effective_year} from {datetime_col} for chip naming")
-    elif year is not None:
-        log(f"Using --year {year} for temporal extent")
-    else:
-        raise ValueError(
-            "Cannot determine temporal extent for STAC catalog. "
-            "Either provide --year parameter or ensure fields file has "
-            "'determination_datetime' column."
-        )
-
-    # Create output directory structure
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    # Chips base directory (will contain per-grid subdirectories)
-    chips_base_dir = out_dir / f"{field_dataset}-chips"
-    chips_base_dir.mkdir(exist_ok=True)
-
-    # Step 1: Check CRS and reproject if needed
-    log("Checking CRS...")
-    geom_col = detect_geometry_column(fields_path) or "geometry"
-    crs_info = detect_crs(fields_path, geom_col)
-    source_crs = str(crs_info)
-    was_reprojected = False
-
-    output_fields_path = out_dir / f"{field_dataset}_fields.parquet"
-
-    if crs_info.authority_code is None or crs_info.authority_code.upper() != "EPSG:4326":
-        if skip_reproject:
-            raise ValueError(
-                f"Input file has CRS '{crs_info}' but EPSG:4326 is required. "
-                "Remove --skip-reproject to auto-reproject."
-            )
-
-        log(f"Reprojecting from {crs_info} to EPSG:4326...")
-        reproject_result = reproject(
-            fields_path,
-            output_fields_path,
-            target_crs="EPSG:4326",
-            on_progress=log,
-        )
-        fields_path = reproject_result.output_path
-        was_reprojected = True
-        log(f"Reprojected to: {output_fields_path}")
-    else:
-        # Copy fields file to output directory
-        log("CRS is already EPSG:4326, copying to output directory...")
-        shutil.copy2(fields_path, output_fields_path)
-        fields_path = output_fields_path
-
-    # Step 2: Create chips
-    log("Creating chips with field coverage statistics...")
-    chips_path = out_dir / f"{field_dataset}_chips.parquet"
-
-    chips_result = field_stats.add_field_stats(
-        fields_file=str(fields_path),
-        grid_file=None,  # Use default FTW grid from Source Coop
-        output_file=str(chips_path),
-        min_coverage=min_coverage,
-        drop_border_chips=drop_border_chips,
-        on_progress=log,
-    )
-    log(
-        f"Created chips: {chips_result.total_cells:,} cells, {chips_result.cells_with_coverage:,} with coverage"
-    )
-
-    # Step 3: Assign splits
-    log(f"Assigning {split_type} splits...")
-    splits_result = splits.assign_splits(
-        chips_file=str(chips_path),
+    # Build a config from the keyword arguments so this flag-driven entry point
+    # runs through the same stage engine as the config-driven ``ftwd run``.
+    config = DatasetConfig.from_kwargs(
+        fields_file=str(fields_file),
+        output_dir=str(output_dir) if output_dir is not None else None,
+        field_dataset=field_dataset,
         split_type=split_type,
         split_percents=split_percents,
-        random_seed=42,
-        fields_file=str(fields_path),
-        on_progress=log,
+        min_coverage=min_coverage,
+        resolution=resolution,
+        num_workers=num_workers,
+        skip_reproject=skip_reproject,
+        year=year,
+        mask_types=mask_types,
+        presence_only=presence_only,
+        drop_border_chips=drop_border_chips,
     )
+    provenance = config.provenance_dict()
 
-    # Step 4: Create boundary lines
-    log("Creating boundary lines...")
-    boundary_lines_path = out_dir / f"{field_dataset}_boundary_lines.parquet"
-
-    boundaries_result = boundaries.create_boundaries(
-        input_path=str(fields_path),
-        output_dir=str(out_dir),
-        output_prefix=f"{field_dataset}_boundary_lines_",
-        on_progress=log,
+    ctx = pipeline.build_context(
+        config,
+        on_progress=on_progress,
+        on_mask_progress=on_mask_progress,
+        on_mask_start=on_mask_start,
+        provenance=provenance,
     )
-
-    # Rename the output file to match our naming convention
-    if boundaries_result.files_processed:
-        original_output = boundaries_result.files_processed[0].output_path
-        if original_output != boundary_lines_path:
-            shutil.move(str(original_output), str(boundary_lines_path))
-
-    log(f"Created boundary lines: {boundaries_result.total_features:,} features")
-
-    # Step 5: Create masks for all three types
-    masks_results: dict[str, masks.CreateMasksResult] = {}
-
-    # Get list of grid IDs from chips file to create directories
-    conn = duckdb.connect(":memory:")
-    ensure_spatial_loaded(conn)
-    grid_ids = conn.execute(f"""
-        SELECT id FROM '{chips_path}'
-        WHERE field_coverage_pct >= {min_coverage}
-    """).fetchall()
-    conn.close()
-
-    # Create chip directories and build mapping
-    # Directory names include year if provided (e.g., ftw-34UFF1628_2024)
-    chip_dirs: dict[str, Path] = {}
-    for (grid_id,) in grid_ids:
-        grid_id_str = str(grid_id)
-        item_id = get_item_id(grid_id_str, effective_year)
-        chip_dir = chips_base_dir / item_id
-        chip_dir.mkdir(exist_ok=True)
-        chip_dirs[item_id] = chip_dir
-
-    log(f"Created {len(chip_dirs)} chip directories")
-
-    # Default to all mask types if not specified
-    if mask_types is None:
-        mask_types = ["instance", "semantic_2_class", "semantic_3_class"]
-
-    # Map string names to enum values and subdirectory names
-    mask_type_mapping = [
-        (MaskType.INSTANCE, "instance", "instance"),
-        (MaskType.SEMANTIC_2_CLASS, "semantic_2class", "semantic_2_class"),
-        (MaskType.SEMANTIC_3_CLASS, "semantic_3class", "semantic_3_class"),
-    ]
-
-    # Filter to only requested mask types
-    requested_masks = [
-        (mask_type, subdir_name)
-        for mask_type, subdir_name, type_name in mask_type_mapping
-        if type_name in mask_types
-    ]
-
-    for mask_type, subdir_name in requested_masks:
-        log(f"Creating {mask_type.value} masks...")
-
-        mask_result = masks.create_masks(
-            chips_file=str(chips_path),
-            boundaries_file=str(fields_path),
-            boundary_lines_file=str(boundary_lines_path),
-            output_dir=str(chips_base_dir),  # Fallback, not used when chip_dirs provided
-            field_dataset=field_dataset,
-            mask_type=mask_type,
-            min_coverage=min_coverage,
-            resolution=resolution,
-            num_workers=num_workers,
-            chip_dirs=chip_dirs,
-            year=effective_year,
-            background_class_value=3 if presence_only else 0,
-            on_progress=on_mask_progress,
-            on_start=on_mask_start,
-        )
-
-        masks_results[subdir_name] = mask_result
-        log(f"Created {mask_result.total_created} {mask_type.value} masks")
-
-    # Step 6: Generate STAC catalog
-    log("Generating STAC catalog...")
-    stac_result = stac.generate_stac_catalog(
-        output_dir=out_dir,
-        field_dataset=field_dataset,
-        fields_file=output_fields_path,
-        chips_file=chips_path,
-        boundary_lines_file=boundary_lines_path,
-        chips_base_dir=chips_base_dir,
-        year=effective_year,
-        on_progress=log,
-    )
-    log(f"Created STAC catalog with {stac_result.total_items} items")
-
-    log("Dataset creation complete!")
+    # Imagery stages are disabled in from_kwargs(), so this runs reproject..stac.
+    stages = pipeline.resolve_stages(config=config)
+    pipeline.run_pipeline(ctx, stages)
 
     return CreateDatasetResult(
-        output_dir=out_dir,
-        field_dataset=field_dataset,
-        fields_file=output_fields_path,
-        chips_file=chips_path,
-        boundary_lines_file=boundary_lines_path,
-        chips_base_dir=chips_base_dir,
-        was_reprojected=was_reprojected,
-        source_crs=source_crs,
-        chips_result=chips_result,
-        splits_result=splits_result,
-        boundaries_result=boundaries_result,
-        masks_results=masks_results,
-        stac_result=stac_result,
+        output_dir=ctx.output_dir,
+        field_dataset=ctx.field_dataset,
+        fields_file=ctx.output_fields_path,
+        chips_file=ctx.chips_path,
+        boundary_lines_file=ctx.boundary_lines_path,
+        chips_base_dir=ctx.chips_base_dir,
+        was_reprojected=ctx.was_reprojected,
+        source_crs=ctx.source_crs,
+        chips_result=ctx.chips_result,
+        splits_result=ctx.splits_result,
+        boundaries_result=ctx.boundaries_result,
+        masks_results=ctx.masks_results,
+        stac_result=ctx.stac_result,
     )

--- a/src/ftw_dataset_tools/api/pipeline.py
+++ b/src/ftw_dataset_tools/api/pipeline.py
@@ -1,0 +1,460 @@
+"""Stage-based orchestration for FTW dataset creation.
+
+This module is the single source of truth for the dataset build pipeline. Each
+stage is a small function operating on a :class:`PipelineContext`; the flag-driven
+``create-dataset`` command and the config-driven ``ftwd run`` command both build a
+context and execute the same stages.
+
+Intermediate outputs live in the output directory under a fixed naming
+convention, so any stage can be re-run on its own as long as its inputs exist:
+
+    {output_dir}/{name}_fields.parquet          (reproject)
+    {output_dir}/{name}_chips.parquet           (chips, splits)
+    {output_dir}/{name}_boundary_lines.parquet  (boundaries)
+    {output_dir}/{name}-chips/                   (masks, stac, imagery)
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import duckdb
+
+from ftw_dataset_tools.api import boundaries, field_stats, masks, splits, stac
+from ftw_dataset_tools.api import config as config_module
+from ftw_dataset_tools.api.geo import (
+    detect_crs,
+    detect_geometry_column,
+    ensure_spatial_loaded,
+    reproject,
+)
+from ftw_dataset_tools.api.imagery import (
+    download_imagery_for_catalog,
+    select_imagery_for_catalog,
+)
+from ftw_dataset_tools.api.masks import MaskType, get_item_id
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ftw_dataset_tools.api.config import DatasetConfig
+
+# Ordered list of all pipeline stages.
+STAGE_ORDER = [
+    "reproject",
+    "chips",
+    "splits",
+    "boundaries",
+    "masks",
+    "stac",
+    "select_images",
+    "download_images",
+]
+
+# Stages that require a resolvable calendar year (for chip naming, temporal
+# extent, or imagery search).
+_YEAR_STAGES = {"masks", "stac", "select_images", "download_images"}
+
+
+class StageInputError(ValueError):
+    """Raised when a stage is run without its required input files present."""
+
+
+@dataclass
+class PipelineContext:
+    """Mutable state threaded through pipeline stages."""
+
+    config: DatasetConfig
+    fields_input: Path
+    output_dir: Path
+    field_dataset: str
+    effective_year: int | None
+    has_temporal: bool
+    provenance: dict[str, Any] | None = None
+    on_progress: Callable[[str], None] | None = None
+    on_mask_progress: Callable[[int, int], None] | None = None
+    on_mask_start: Callable[[int, int], None] | None = None
+
+    # Accumulated results / state, populated as stages run.
+    was_reprojected: bool = False
+    source_crs: str | None = None
+    chips_result: field_stats.FieldStatsResult | None = None
+    splits_result: splits.CreateSplitsResult | None = None
+    boundaries_result: boundaries.CreateBoundariesResult | None = None
+    masks_results: dict[str, masks.CreateMasksResult] = field(default_factory=dict)
+    stac_result: stac.STACGenerationResult | None = None
+    selection_result: Any = None
+    download_result: Any = None
+
+    # Derived output paths (fixed naming convention).
+    output_fields_path: Path = field(init=False)
+    chips_path: Path = field(init=False)
+    boundary_lines_path: Path = field(init=False)
+    chips_base_dir: Path = field(init=False)
+
+    def __post_init__(self) -> None:
+        name = self.field_dataset
+        self.output_fields_path = self.output_dir / f"{name}_fields.parquet"
+        self.chips_path = self.output_dir / f"{name}_chips.parquet"
+        self.boundary_lines_path = self.output_dir / f"{name}_boundary_lines.parquet"
+        self.chips_base_dir = self.output_dir / f"{name}-chips"
+
+    def log(self, msg: str) -> None:
+        if self.on_progress:
+            self.on_progress(msg)
+
+
+def build_context(
+    config: DatasetConfig,
+    *,
+    on_progress: Callable[[str], None] | None = None,
+    on_mask_progress: Callable[[int, int], None] | None = None,
+    on_mask_start: Callable[[int, int], None] | None = None,
+    provenance: dict[str, Any] | None = None,
+) -> PipelineContext:
+    """Resolve paths, detect temporal extent, and prepare the output directory.
+
+    Raises:
+        FileNotFoundError: If the input fields file does not exist.
+    """
+    fields_path = Path(config.fields_file).resolve()
+    if not fields_path.exists():
+        raise FileNotFoundError(f"Fields file not found: {fields_path}")
+
+    field_dataset = config.name or fields_path.stem
+    out_dir = (
+        Path(config.output_dir).resolve()
+        if config.output_dir is not None
+        else Path(f"{fields_path.stem}-dataset").resolve()
+    )
+
+    def log(msg: str) -> None:
+        if on_progress:
+            on_progress(msg)
+
+    # Resolve the calendar year (year arg wins; else derive from datetime column).
+    log("Checking temporal extent availability...")
+    datetime_col = stac.detect_datetime_column(fields_path)
+    effective_year = config.year
+    if datetime_col:
+        log(f"Found '{datetime_col}' column for temporal extent")
+        if effective_year is None:
+            effective_year = stac.get_year_from_datetime_column(fields_path, datetime_col)
+            if effective_year:
+                log(f"Using year {effective_year} from {datetime_col} for chip naming")
+    elif config.year is not None:
+        log(f"Using year {config.year} for temporal extent")
+
+    has_temporal = datetime_col is not None or config.year is not None
+
+    ctx = PipelineContext(
+        config=config,
+        fields_input=fields_path,
+        output_dir=out_dir,
+        field_dataset=field_dataset,
+        effective_year=effective_year,
+        has_temporal=has_temporal,
+        provenance=provenance,
+        on_progress=on_progress,
+        on_mask_progress=on_mask_progress,
+        on_mask_start=on_mask_start,
+    )
+    return ctx
+
+
+def resolve_stages(
+    only: str | None = None,
+    from_stage: str | None = None,
+    through_stage: str | None = None,
+    *,
+    config: DatasetConfig | None = None,
+) -> list[str]:
+    """Determine which stages to run from --only/--from/--through selectors.
+
+    Enabled-gated imagery stages are dropped from a range/full run when their
+    config section is disabled, but ``--only`` always forces the named stage.
+    """
+    for name in (only, from_stage, through_stage):
+        if name is not None and name not in STAGE_ORDER:
+            raise ValueError(f"Unknown stage '{name}'. Valid stages: {', '.join(STAGE_ORDER)}.")
+
+    if only is not None:
+        return [only]
+
+    start = STAGE_ORDER.index(from_stage) if from_stage else 0
+    end = STAGE_ORDER.index(through_stage) + 1 if through_stage else len(STAGE_ORDER)
+    selected = STAGE_ORDER[start:end]
+
+    if config is not None:
+        selected = [s for s in selected if _stage_enabled(s, config)]
+    return selected
+
+
+def _stage_enabled(stage: str, config: DatasetConfig) -> bool:
+    if stage == "select_images":
+        return config.stages.select_images.enabled
+    if stage == "download_images":
+        return config.stages.download_images.enabled
+    return True
+
+
+def run_pipeline(ctx: PipelineContext, stages_to_run: list[str]) -> PipelineContext:
+    """Validate and execute the requested stages in order, mutating ``ctx``."""
+    _validate_stage_selection(ctx, stages_to_run)
+
+    ctx.output_dir.mkdir(parents=True, exist_ok=True)
+    ctx.chips_base_dir.mkdir(exist_ok=True)
+    if ctx.provenance is not None:
+        config_module.write_provenance_file(ctx.provenance, ctx.output_dir)
+
+    for stage in STAGE_ORDER:
+        if stage in stages_to_run:
+            _STAGE_FUNCS[stage](ctx)
+
+    ctx.log("Pipeline complete!")
+    return ctx
+
+
+def _validate_stage_selection(ctx: PipelineContext, stages_to_run: list[str]) -> None:
+    """Front-load validation so failures surface before any heavy work runs."""
+    if "splits" in stages_to_run:
+        split_type = ctx.config.stages.splits.split_type
+        if split_type is None:
+            raise ValueError("split_type is required and cannot be None")
+        if split_type not in splits.SPLIT_TYPE_CHOICES:
+            raise ValueError(f"split_type must be one of: {splits.SPLIT_TYPE_CHOICES_STR}")
+
+    if any(s in _YEAR_STAGES for s in stages_to_run) and not ctx.has_temporal:
+        raise ValueError(
+            "Cannot determine temporal extent for STAC catalog. "
+            "Either provide a 'year' or ensure the fields file has a "
+            "'determination_datetime' column."
+        )
+
+
+def _require(path: Path, *, stage: str, produced_by: str) -> None:
+    """Ensure a stage's input exists, with a clear message for standalone runs."""
+    if not path.exists():
+        raise StageInputError(
+            f"Stage '{stage}' requires {path.name}, which is missing. "
+            f"Run the '{produced_by}' stage first."
+        )
+
+
+# ---- stage implementations ----------------------------------------------
+
+
+def stage_reproject(ctx: PipelineContext) -> None:
+    """Reproject the input to EPSG:4326 if needed, else copy it into the output."""
+    ctx.log("Checking CRS...")
+    geom_col = detect_geometry_column(ctx.fields_input) or "geometry"
+    crs_info = detect_crs(ctx.fields_input, geom_col)
+    ctx.source_crs = str(crs_info)
+
+    if crs_info.authority_code is None or crs_info.authority_code.upper() != "EPSG:4326":
+        if ctx.config.skip_reproject:
+            raise ValueError(
+                f"Input file has CRS '{crs_info}' but EPSG:4326 is required. "
+                "Remove skip_reproject to auto-reproject."
+            )
+        ctx.log(f"Reprojecting from {crs_info} to EPSG:4326...")
+        reproject(
+            ctx.fields_input,
+            ctx.output_fields_path,
+            target_crs="EPSG:4326",
+            on_progress=ctx.log,
+        )
+        ctx.was_reprojected = True
+        ctx.log(f"Reprojected to: {ctx.output_fields_path}")
+    else:
+        ctx.log("CRS is already EPSG:4326, copying to output directory...")
+        shutil.copy2(ctx.fields_input, ctx.output_fields_path)
+
+
+def stage_chips(ctx: PipelineContext) -> None:
+    """Create chips with field coverage statistics."""
+    _require(ctx.output_fields_path, stage="chips", produced_by="reproject")
+    ctx.log("Creating chips with field coverage statistics...")
+    ctx.chips_result = field_stats.add_field_stats(
+        fields_file=str(ctx.output_fields_path),
+        grid_file=None,
+        output_file=str(ctx.chips_path),
+        min_coverage=ctx.config.stages.chips.min_coverage,
+        drop_border_chips=ctx.config.stages.chips.drop_border_chips,
+        on_progress=ctx.log,
+    )
+    ctx.log(
+        f"Created chips: {ctx.chips_result.total_cells:,} cells, "
+        f"{ctx.chips_result.cells_with_coverage:,} with coverage"
+    )
+
+
+def stage_splits(ctx: PipelineContext) -> None:
+    """Assign train/val/test splits to the chips file."""
+    _require(ctx.chips_path, stage="splits", produced_by="chips")
+    split_cfg = ctx.config.stages.splits
+    ctx.log(f"Assigning {split_cfg.split_type} splits...")
+    ctx.splits_result = splits.assign_splits(
+        chips_file=str(ctx.chips_path),
+        split_type=split_cfg.split_type,
+        split_percents=split_cfg.split_percents,
+        random_seed=split_cfg.random_seed,
+        fields_file=str(ctx.output_fields_path),
+        on_progress=ctx.log,
+    )
+
+
+def stage_boundaries(ctx: PipelineContext) -> None:
+    """Create boundary lines from field polygons."""
+    _require(ctx.output_fields_path, stage="boundaries", produced_by="reproject")
+    ctx.log("Creating boundary lines...")
+    result = boundaries.create_boundaries(
+        input_path=str(ctx.output_fields_path),
+        output_dir=str(ctx.output_dir),
+        output_prefix=f"{ctx.field_dataset}_boundary_lines_",
+        on_progress=ctx.log,
+    )
+    # Rename to the canonical naming convention.
+    if result.files_processed:
+        original_output = result.files_processed[0].output_path
+        if original_output != ctx.boundary_lines_path:
+            shutil.move(str(original_output), str(ctx.boundary_lines_path))
+    ctx.boundaries_result = result
+    ctx.log(f"Created boundary lines: {result.total_features:,} features")
+
+
+# String name -> (enum, subdir key used as masks_results key).
+_MASK_TYPE_MAPPING = [
+    (MaskType.INSTANCE, "instance", "instance"),
+    (MaskType.SEMANTIC_2_CLASS, "semantic_2class", "semantic_2_class"),
+    (MaskType.SEMANTIC_3_CLASS, "semantic_3class", "semantic_3_class"),
+]
+
+
+def _build_chip_dirs(ctx: PipelineContext) -> dict[str, Path]:
+    """Create per-chip directories for grids above the coverage threshold."""
+    min_coverage = ctx.config.stages.chips.min_coverage
+    conn = duckdb.connect(":memory:")
+    ensure_spatial_loaded(conn)
+    grid_ids = conn.execute(
+        f"SELECT id FROM '{ctx.chips_path}' WHERE field_coverage_pct >= {min_coverage}"
+    ).fetchall()
+    conn.close()
+
+    chip_dirs: dict[str, Path] = {}
+    for (grid_id,) in grid_ids:
+        item_id = get_item_id(str(grid_id), ctx.effective_year)
+        chip_dir = ctx.chips_base_dir / item_id
+        chip_dir.mkdir(exist_ok=True)
+        chip_dirs[item_id] = chip_dir
+    return chip_dirs
+
+
+def stage_masks(ctx: PipelineContext) -> None:
+    """Create the requested raster mask types for each chip."""
+    _require(ctx.chips_path, stage="masks", produced_by="chips")
+    _require(ctx.output_fields_path, stage="masks", produced_by="reproject")
+    _require(ctx.boundary_lines_path, stage="masks", produced_by="boundaries")
+
+    chip_dirs = _build_chip_dirs(ctx)
+    ctx.log(f"Created {len(chip_dirs)} chip directories")
+
+    masks_cfg = ctx.config.stages.masks
+    requested = [
+        (mask_type, subdir_name)
+        for mask_type, subdir_name, type_name in _MASK_TYPE_MAPPING
+        if type_name in masks_cfg.mask_types
+    ]
+    background_class_value = 3 if masks_cfg.presence_only else 0
+
+    for mask_type, subdir_name in requested:
+        ctx.log(f"Creating {mask_type.value} masks...")
+        mask_result = masks.create_masks(
+            chips_file=str(ctx.chips_path),
+            boundaries_file=str(ctx.output_fields_path),
+            boundary_lines_file=str(ctx.boundary_lines_path),
+            output_dir=str(ctx.chips_base_dir),
+            field_dataset=ctx.field_dataset,
+            mask_type=mask_type,
+            min_coverage=ctx.config.stages.chips.min_coverage,
+            resolution=masks_cfg.resolution,
+            num_workers=masks_cfg.workers,
+            chip_dirs=chip_dirs,
+            year=ctx.effective_year,
+            background_class_value=background_class_value,
+            on_progress=ctx.on_mask_progress,
+            on_start=ctx.on_mask_start,
+        )
+        ctx.masks_results[subdir_name] = mask_result
+        ctx.log(f"Created {mask_result.total_created} {mask_type.value} masks")
+
+
+def stage_stac(ctx: PipelineContext) -> None:
+    """Generate the STAC static catalog, embedding provenance if available."""
+    _require(ctx.chips_path, stage="stac", produced_by="chips")
+    _require(ctx.output_fields_path, stage="stac", produced_by="reproject")
+    _require(ctx.boundary_lines_path, stage="stac", produced_by="boundaries")
+
+    ctx.log("Generating STAC catalog...")
+    ctx.stac_result = stac.generate_stac_catalog(
+        output_dir=ctx.output_dir,
+        field_dataset=ctx.field_dataset,
+        fields_file=ctx.output_fields_path,
+        chips_file=ctx.chips_path,
+        boundary_lines_file=ctx.boundary_lines_path,
+        chips_base_dir=ctx.chips_base_dir,
+        year=ctx.effective_year,
+        provenance=ctx.provenance,
+        on_progress=ctx.log,
+    )
+    ctx.log(f"Created STAC catalog with {ctx.stac_result.total_items} items")
+
+
+def stage_select_images(ctx: PipelineContext) -> None:
+    """Select cloud-free Sentinel-2 scenes for each chip."""
+    _require(ctx.chips_base_dir / "collection.json", stage="select_images", produced_by="stac")
+    if ctx.effective_year is None:
+        raise ValueError("A year is required for image selection.")
+
+    select_cfg = ctx.config.stages.select_images
+    ctx.log("Selecting imagery...")
+    ctx.selection_result = select_imagery_for_catalog(
+        catalog_dir=ctx.chips_base_dir,
+        year=ctx.effective_year,
+        cloud_cover_chip=select_cfg.cloud_cover_chip,
+        nodata_max=select_cfg.nodata_max,
+        buffer_days=select_cfg.buffer_days,
+        num_buffer_expansions=select_cfg.num_buffer_expansions,
+        buffer_expansion_size=select_cfg.buffer_expansion_size,
+    )
+
+
+def stage_download_images(ctx: PipelineContext) -> None:
+    """Download selected imagery and generate thumbnails."""
+    _require(
+        ctx.chips_base_dir / "collection.json",
+        stage="download_images",
+        produced_by="stac",
+    )
+    download_cfg = ctx.config.stages.download_images
+    ctx.log("Downloading imagery...")
+    ctx.download_result = download_imagery_for_catalog(
+        catalog_dir=ctx.chips_base_dir,
+        bands=download_cfg.bands,
+        resolution=download_cfg.resolution,
+    )
+
+
+_STAGE_FUNCS: dict[str, Callable[[PipelineContext], None]] = {
+    "reproject": stage_reproject,
+    "chips": stage_chips,
+    "splits": stage_splits,
+    "boundaries": stage_boundaries,
+    "masks": stage_masks,
+    "stac": stage_stac,
+    "select_images": stage_select_images,
+    "download_images": stage_download_images,
+}

--- a/src/ftw_dataset_tools/api/stac.py
+++ b/src/ftw_dataset_tools/api/stac.py
@@ -261,13 +261,16 @@ def _extract_chips_info(
 def _create_root_catalog(
     dataset_name: str,
     description: str | None = None,
+    provenance: dict | None = None,
 ) -> Catalog:
-    """Create the root STAC catalog."""
+    """Create the root STAC catalog, embedding provenance under ``ftw:config``."""
     catalog = Catalog(
         id=dataset_name,
         description=description or f"FTW training dataset: {dataset_name}",
         title=f"{dataset_name} Dataset",
     )
+    if provenance is not None:
+        catalog.extra_fields["ftw:config"] = provenance
     return catalog
 
 
@@ -519,6 +522,7 @@ def generate_stac_catalog(
     chips_base_dir: Path | None = None,
     mask_dirs: dict[str, Path] | None = None,
     year: int | None = None,
+    provenance: dict | None = None,
     on_progress: Callable[[str], None] | None = None,
 ) -> STACGenerationResult:
     """
@@ -535,6 +539,8 @@ def generate_stac_catalog(
         mask_dirs: Legacy - Dict mapping mask type name to directory path.
                    Ignored if chips_base_dir is provided.
         year: Optional year for temporal extent (required if no determination_datetime)
+        provenance: Optional resolved-config record embedded on the root catalog
+                    under the ``ftw:config`` extra field for reproducibility.
         on_progress: Optional callback for progress messages
 
     Returns:
@@ -604,7 +610,7 @@ def generate_stac_catalog(
 
     # Create root catalog
     log("Creating root catalog...")
-    catalog = _create_root_catalog(field_dataset)
+    catalog = _create_root_catalog(field_dataset, provenance=provenance)
 
     # Create source collection
     log("Creating source collection...")

--- a/src/ftw_dataset_tools/cli.py
+++ b/src/ftw_dataset_tools/cli.py
@@ -13,6 +13,7 @@ from ftw_dataset_tools.commands.create_masks import create_masks
 from ftw_dataset_tools.commands.create_splits import create_splits
 from ftw_dataset_tools.commands.download_images import download_images
 from ftw_dataset_tools.commands.get_grid import get_grid
+from ftw_dataset_tools.commands.run import run
 from ftw_dataset_tools.commands.select_images import select_images
 
 
@@ -42,6 +43,7 @@ cli.add_command(create_masks)
 cli.add_command(create_splits)
 cli.add_command(download_images)
 cli.add_command(get_grid)
+cli.add_command(run)
 cli.add_command(select_images)
 
 

--- a/src/ftw_dataset_tools/commands/run.py
+++ b/src/ftw_dataset_tools/commands/run.py
@@ -1,0 +1,192 @@
+"""CLI command for the config-driven dataset workflow (``ftwd run``)."""
+
+from __future__ import annotations
+
+import sys
+
+import click
+
+from ftw_dataset_tools.api import config as config_module
+from ftw_dataset_tools.api import pipeline
+
+
+def _on_progress(msg: str) -> None:
+    """Color-coded general progress messages (mirrors create-dataset)."""
+    if msg.startswith("Warning:"):
+        click.echo(click.style(msg, fg="yellow"))
+    elif "Error" in msg:
+        click.echo(click.style(msg, fg="red"))
+    elif "Reprojecting" in msg or "CRS" in msg:
+        click.echo(click.style(msg, fg="cyan"))
+    elif "complete" in msg.lower():
+        click.echo(click.style(msg, fg="green"))
+    else:
+        click.echo(msg)
+
+
+def _on_mask_progress(current: int, total: int) -> None:
+    percent = int(100 * current / total) if total > 0 else 0
+    bar_width = 40
+    filled = int(bar_width * current / total) if total > 0 else 0
+    bar = "█" * filled + "░" * (bar_width - filled)
+    sys.stdout.write(f"\r  Creating masks: |{bar}| {current}/{total} ({percent}%)")
+    sys.stdout.flush()
+
+
+def _on_mask_start(total_grids: int, filtered_grids: int) -> None:
+    skipped = total_grids - filtered_grids
+    if skipped > 0:
+        click.echo(f"  Processing {filtered_grids:,} grids (skipping {skipped:,} below threshold)")
+    else:
+        click.echo(f"  Processing {filtered_grids:,} grids")
+
+
+@click.command("run")
+@click.argument("config_file", type=click.Path(exists=True))
+@click.option(
+    "--only",
+    default=None,
+    help="Run a single stage only (e.g. 'masks'). Forces the stage even if disabled.",
+)
+@click.option(
+    "--from",
+    "from_stage",
+    default=None,
+    help="Run from this stage through the end of the pipeline.",
+)
+@click.option(
+    "--through",
+    "through_stage",
+    default=None,
+    help="Run from the first stage through this stage (inclusive).",
+)
+@click.option(
+    "--list-stages",
+    is_flag=True,
+    default=False,
+    help="List the pipeline stages in order and exit.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Show the resolved config and the stages that would run, without executing.",
+)
+def run_cmd(
+    config_file: str,
+    only: str | None,
+    from_stage: str | None,
+    through_stage: str | None,
+    list_stages: bool,
+    dry_run: bool,
+) -> None:
+    """Run the dataset creation pipeline from a YAML config file.
+
+    The config captures every setting for the build, and a fully-resolved copy is
+    written to the output directory (``ftwd-config.resolved.yaml``) and embedded in
+    the STAC catalog for provenance.
+
+    \b
+    CONFIG_FILE: Path to a YAML config file (see examples/config.yaml).
+
+    \b
+    Examples:
+        ftwd run config.yaml
+        ftwd run config.yaml --only masks
+        ftwd run config.yaml --from select_images
+        ftwd run config.yaml --dry-run
+    """
+    if list_stages:
+        click.echo("Pipeline stages (in order):")
+        for stage in pipeline.STAGE_ORDER:
+            click.echo(f"  - {stage}")
+        return
+
+    if only is not None and (from_stage is not None or through_stage is not None):
+        raise click.BadParameter("--only cannot be combined with --from/--through.")
+
+    try:
+        config = config_module.load_config(config_file)
+    except config_module.ConfigError as err:
+        raise click.ClickException(str(err)) from err
+
+    try:
+        stages = pipeline.resolve_stages(
+            only=only,
+            from_stage=from_stage,
+            through_stage=through_stage,
+            config=config,
+        )
+    except ValueError as err:
+        raise click.BadParameter(str(err)) from err
+
+    if not stages:
+        raise click.ClickException(
+            "No stages selected to run. Check enabled flags or stage selectors."
+        )
+
+    provenance = config.provenance_dict()
+
+    if dry_run:
+        import yaml
+
+        click.echo(click.style("Config (resolved):", fg="cyan", bold=True))
+        click.echo(yaml.safe_dump(provenance["config"], sort_keys=False))
+        click.echo(click.style("Stages that would run:", fg="cyan", bold=True))
+        for stage in stages:
+            click.echo(f"  - {stage}")
+        return
+
+    click.echo(click.style("Running dataset pipeline from config", fg="cyan", bold=True))
+    click.echo(f"Config: {config_file}")
+    click.echo(f"Stages: {', '.join(stages)}")
+
+    try:
+        ctx = pipeline.build_context(
+            config,
+            on_progress=_on_progress,
+            on_mask_progress=_on_mask_progress,
+            on_mask_start=_on_mask_start,
+            provenance=provenance,
+        )
+        pipeline.run_pipeline(ctx, stages)
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+    except KeyboardInterrupt:
+        sys.stdout.write("\n")
+        click.echo(click.style("Interrupted by user.", fg="yellow"))
+        raise SystemExit(130) from None
+    except (FileNotFoundError, ValueError, pipeline.StageInputError) as err:
+        click.echo(click.style(f"\nError: {err}", fg="red"))
+        raise SystemExit(1) from err
+
+    _print_summary(ctx)
+
+
+def _print_summary(ctx: pipeline.PipelineContext) -> None:
+    """Print a short summary of what the run produced."""
+    click.echo("")
+    click.echo(click.style("Pipeline finished!", fg="green", bold=True))
+    click.echo(f"  Output: {ctx.output_dir}")
+    click.echo(f"  Provenance: {ctx.output_dir / 'ftwd-config.resolved.yaml'}")
+
+    if ctx.chips_result:
+        click.echo(f"  Grid cells with coverage: {ctx.chips_result.cells_with_coverage:,}")
+    if ctx.splits_result:
+        click.echo(
+            f"  Splits: {ctx.splits_result.train_count} train, "
+            f"{ctx.splits_result.val_count} val, {ctx.splits_result.test_count} test"
+        )
+    if ctx.masks_results:
+        total = sum(r.total_created for r in ctx.masks_results.values())
+        click.echo(f"  Masks created: {total:,}")
+    if ctx.stac_result:
+        click.echo(f"  STAC items: {ctx.stac_result.total_items:,}")
+    if ctx.selection_result is not None:
+        click.echo(f"  Imagery selected: {ctx.selection_result.successful}")
+    if ctx.download_result is not None:
+        click.echo(f"  Imagery downloaded: {ctx.download_result.successful}")
+
+
+# Alias for registration
+run = run_cmd

--- a/tests/test_api/test_config.py
+++ b/tests/test_api/test_config.py
@@ -1,0 +1,211 @@
+"""Tests for the config-driven workflow schema and loading."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from ftw_dataset_tools.api import config as config_module
+from ftw_dataset_tools.api.config import ConfigError, DatasetConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestFromDict:
+    """Tests for DatasetConfig.from_dict parsing and defaults."""
+
+    def test_minimal_config_fills_defaults(self) -> None:
+        config = DatasetConfig.from_dict({"fields_file": "fields.parquet"})
+        assert config.fields_file == "fields.parquet"
+        assert config.output_dir is None
+        assert config.name is None
+        assert config.skip_reproject is False
+        # Stage defaults
+        assert config.stages.chips.min_coverage == 0.01
+        assert config.stages.splits.split_percents == (80, 10, 10)
+        assert config.stages.masks.mask_types == [
+            "instance",
+            "semantic_2_class",
+            "semantic_3_class",
+        ]
+        assert config.stages.select_images.enabled is True
+        assert config.stages.download_images.enabled is False
+
+    def test_full_config_overrides(self) -> None:
+        config = DatasetConfig.from_dict(
+            {
+                "version": 1,
+                "fields_file": "f.parquet",
+                "output_dir": "./out",
+                "name": "austria",
+                "year": 2023,
+                "skip_reproject": True,
+                "stages": {
+                    "chips": {"min_coverage": 0.5, "drop_border_chips": True},
+                    "splits": {"split_type": "block3x3", "split_percents": [70, 20, 10]},
+                    "masks": {"mask_types": ["semantic_2_class"], "resolution": 5.0},
+                    "select_images": {"enabled": False, "buffer_days": 30},
+                    "download_images": {"enabled": True, "bands": ["red", "green"]},
+                },
+            }
+        )
+        assert config.name == "austria"
+        assert config.year == 2023
+        assert config.skip_reproject is True
+        assert config.stages.chips.min_coverage == 0.5
+        assert config.stages.splits.split_type == "block3x3"
+        assert config.stages.splits.split_percents == (70, 20, 10)
+        assert config.stages.masks.mask_types == ["semantic_2_class"]
+        assert config.stages.masks.resolution == 5.0
+        assert config.stages.select_images.enabled is False
+        assert config.stages.select_images.buffer_days == 30
+        assert config.stages.download_images.bands == ["red", "green"]
+
+    def test_missing_fields_file_raises(self) -> None:
+        with pytest.raises(ConfigError, match="must specify 'fields_file'"):
+            DatasetConfig.from_dict({"year": 2023})
+
+    def test_unknown_top_level_key_raises(self) -> None:
+        with pytest.raises(ConfigError, match="Unknown key"):
+            DatasetConfig.from_dict({"fields_file": "f.parquet", "bogus": 1})
+
+    def test_unknown_stage_key_raises(self) -> None:
+        with pytest.raises(ConfigError, match=r"Unknown key.*stages"):
+            DatasetConfig.from_dict({"fields_file": "f.parquet", "stages": {"bogus": {}}})
+
+    def test_unknown_stage_option_raises(self) -> None:
+        with pytest.raises(ConfigError, match=r"stages\.chips"):
+            DatasetConfig.from_dict(
+                {"fields_file": "f.parquet", "stages": {"chips": {"bad_option": 1}}}
+            )
+
+    def test_invalid_split_type_raises(self) -> None:
+        with pytest.raises(ConfigError, match="Invalid split_type"):
+            DatasetConfig.from_dict(
+                {"fields_file": "f.parquet", "stages": {"splits": {"split_type": "nope"}}}
+            )
+
+    def test_invalid_split_percents_raises(self) -> None:
+        with pytest.raises(ConfigError, match="split_percents"):
+            DatasetConfig.from_dict(
+                {"fields_file": "f.parquet", "stages": {"splits": {"split_percents": [50, 10, 10]}}}
+            )
+
+    def test_invalid_mask_type_raises(self) -> None:
+        with pytest.raises(ConfigError, match="Invalid mask type"):
+            DatasetConfig.from_dict(
+                {"fields_file": "f.parquet", "stages": {"masks": {"mask_types": ["nope"]}}}
+            )
+
+    def test_root_must_be_mapping(self) -> None:
+        with pytest.raises(ConfigError, match="mapping"):
+            DatasetConfig.from_dict([1, 2, 3])  # type: ignore[arg-type]
+
+
+class TestFromKwargs:
+    """Tests for building a config from create_dataset kwargs."""
+
+    def test_maps_kwargs_and_disables_imagery(self) -> None:
+        config = DatasetConfig.from_kwargs(
+            fields_file="f.parquet",
+            output_dir="./out",
+            field_dataset="ds",
+            split_type="random-uniform",
+            split_percents=(80, 10, 10),
+            min_coverage=0.02,
+            resolution=20.0,
+            num_workers=4,
+            skip_reproject=False,
+            year=2022,
+            mask_types=["instance"],
+            presence_only=True,
+            drop_border_chips=True,
+        )
+        assert config.name == "ds"
+        assert config.stages.chips.min_coverage == 0.02
+        assert config.stages.chips.drop_border_chips is True
+        assert config.stages.masks.workers == 4
+        assert config.stages.masks.presence_only is True
+        assert config.stages.masks.mask_types == ["instance"]
+        # create_dataset never runs imagery itself
+        assert config.stages.select_images.enabled is False
+        assert config.stages.download_images.enabled is False
+
+    def test_none_mask_types_defaults_to_all(self) -> None:
+        config = DatasetConfig.from_kwargs(
+            fields_file="f.parquet",
+            output_dir=None,
+            field_dataset=None,
+            split_type="random-uniform",
+            split_percents=(80, 10, 10),
+            min_coverage=0.01,
+            resolution=10.0,
+            num_workers=None,
+            skip_reproject=False,
+            year=None,
+            mask_types=None,
+            presence_only=False,
+            drop_border_chips=False,
+        )
+        assert config.stages.masks.mask_types == list(config_module.VALID_MASK_TYPES)
+
+
+class TestProvenance:
+    """Tests for provenance / resolved-config output."""
+
+    def test_provenance_dict_shape(self) -> None:
+        config = DatasetConfig.from_dict({"fields_file": "f.parquet", "year": 2023})
+        prov = config.provenance_dict()
+        assert prov["ftwd_version"]
+        assert prov["config_schema_version"] == config_module.CONFIG_SCHEMA_VERSION
+        assert "generated_at" in prov
+        assert prov["config"]["fields_file"] == "f.parquet"
+        # split_percents serialized as a list (YAML-friendly), not a tuple.
+        assert prov["config"]["stages"]["splits"]["split_percents"] == [80, 10, 10]
+
+    def test_write_provenance_file_roundtrips(self, tmp_path: Path) -> None:
+        config = DatasetConfig.from_dict({"fields_file": "f.parquet", "year": 2023})
+        prov = config.provenance_dict()
+        out = config_module.write_provenance_file(prov, tmp_path)
+        assert out.exists()
+        assert out.name == "ftwd-config.resolved.yaml"
+        loaded = yaml.safe_load(out.read_text())
+        assert loaded["config"]["fields_file"] == "f.parquet"
+
+
+class TestLoadConfig:
+    """Tests for loading a config from a YAML file."""
+
+    def test_load_valid_file(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "fields_file": "f.parquet",
+                    "year": 2023,
+                    "stages": {"splits": {"split_type": "random-uniform"}},
+                }
+            )
+        )
+        config = config_module.load_config(config_path)
+        assert config.year == 2023
+        assert config.stages.splits.split_type == "random-uniform"
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigError, match="not found"):
+            config_module.load_config(tmp_path / "nope.yaml")
+
+    def test_empty_file_raises(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "empty.yaml"
+        config_path.write_text("")
+        with pytest.raises(ConfigError, match="empty"):
+            config_module.load_config(config_path)
+
+    def test_malformed_yaml_raises(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "bad.yaml"
+        config_path.write_text("fields_file: [unclosed")
+        with pytest.raises(ConfigError, match="parse"):
+            config_module.load_config(config_path)

--- a/tests/test_api/test_pipeline.py
+++ b/tests/test_api/test_pipeline.py
@@ -1,0 +1,196 @@
+"""Tests for the stage-based pipeline orchestration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ftw_dataset_tools.api import pipeline
+from ftw_dataset_tools.api.config import DatasetConfig
+from ftw_dataset_tools.api.pipeline import StageInputError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _config(fields_file: Path, output_dir: Path, **kwargs: object) -> DatasetConfig:
+    data: dict = {"fields_file": str(fields_file), "output_dir": str(output_dir)}
+    data.update(kwargs)  # type: ignore[arg-type]
+    return DatasetConfig.from_dict(data)
+
+
+class TestResolveStages:
+    """Tests for stage selection logic."""
+
+    def test_full_run_gates_disabled_imagery(self) -> None:
+        config = DatasetConfig.from_dict({"fields_file": "f.parquet"})
+        stages = pipeline.resolve_stages(config=config)
+        # select_images defaults enabled; download_images defaults disabled.
+        assert stages == [
+            "reproject",
+            "chips",
+            "splits",
+            "boundaries",
+            "masks",
+            "stac",
+            "select_images",
+        ]
+
+    def test_download_enabled_included(self) -> None:
+        config = DatasetConfig.from_dict(
+            {"fields_file": "f.parquet", "stages": {"download_images": {"enabled": True}}}
+        )
+        assert "download_images" in pipeline.resolve_stages(config=config)
+
+    def test_only_forces_single_stage(self) -> None:
+        config = DatasetConfig.from_dict(
+            {"fields_file": "f.parquet", "stages": {"download_images": {"enabled": False}}}
+        )
+        # --only forces a stage even if its config is disabled.
+        assert pipeline.resolve_stages(only="download_images", config=config) == ["download_images"]
+
+    def test_from_and_through(self) -> None:
+        config = DatasetConfig.from_dict({"fields_file": "f.parquet"})
+        assert pipeline.resolve_stages(from_stage="masks", config=config) == [
+            "masks",
+            "stac",
+            "select_images",
+        ]
+        assert pipeline.resolve_stages(through_stage="chips", config=config) == [
+            "reproject",
+            "chips",
+        ]
+
+    def test_unknown_stage_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown stage"):
+            pipeline.resolve_stages(only="bogus")
+
+
+class TestBuildContext:
+    """Tests for context construction and temporal detection."""
+
+    def test_missing_input_raises(self, tmp_path: Path) -> None:
+        config = _config(tmp_path / "nope.parquet", tmp_path / "out")
+        with pytest.raises(FileNotFoundError, match="Fields file not found"):
+            pipeline.build_context(config)
+
+    def test_derived_paths_and_name(self, sample_geoparquet_4326: Path, tmp_path: Path) -> None:
+        out = tmp_path / "out"
+        config = _config(sample_geoparquet_4326, out, name="myds", year=2023)
+        ctx = pipeline.build_context(config)
+        assert ctx.field_dataset == "myds"
+        assert ctx.output_fields_path == out.resolve() / "myds_fields.parquet"
+        assert ctx.chips_path == out.resolve() / "myds_chips.parquet"
+        assert ctx.boundary_lines_path == out.resolve() / "myds_boundary_lines.parquet"
+        assert ctx.chips_base_dir == out.resolve() / "myds-chips"
+        assert ctx.effective_year == 2023
+        assert ctx.has_temporal is True
+
+    def test_name_defaults_to_stem(self, sample_geoparquet_4326: Path, tmp_path: Path) -> None:
+        config = _config(sample_geoparquet_4326, tmp_path / "out", year=2023)
+        ctx = pipeline.build_context(config)
+        assert ctx.field_dataset == sample_geoparquet_4326.stem
+
+    def test_no_temporal_without_year_or_column(
+        self, sample_geoparquet_4326: Path, tmp_path: Path
+    ) -> None:
+        config = _config(sample_geoparquet_4326, tmp_path / "out")
+        ctx = pipeline.build_context(config)
+        assert ctx.has_temporal is False
+        assert ctx.effective_year is None
+
+    def test_build_context_does_not_create_output_dir(
+        self, sample_geoparquet_4326: Path, tmp_path: Path
+    ) -> None:
+        out = tmp_path / "out"
+        config = _config(sample_geoparquet_4326, out, year=2023)
+        pipeline.build_context(config)
+        # Directory creation is deferred to run_pipeline (after validation).
+        assert not out.exists()
+
+
+class TestStageValidation:
+    """Tests for front-loaded validation in run_pipeline."""
+
+    def test_splits_requires_split_type(self, sample_geoparquet_4326: Path, tmp_path: Path) -> None:
+        config = _config(sample_geoparquet_4326, tmp_path / "out", year=2023)
+        ctx = pipeline.build_context(config)
+        with pytest.raises(ValueError, match="split_type is required"):
+            pipeline.run_pipeline(ctx, ["splits"])
+
+    def test_year_stage_requires_temporal(
+        self, sample_geoparquet_4326: Path, tmp_path: Path
+    ) -> None:
+        config = _config(sample_geoparquet_4326, tmp_path / "out")
+        ctx = pipeline.build_context(config)
+        with pytest.raises(ValueError, match="Cannot determine temporal extent"):
+            pipeline.run_pipeline(ctx, ["stac"])
+
+    def test_validation_runs_before_output_dir_created(
+        self, sample_geoparquet_4326: Path, tmp_path: Path
+    ) -> None:
+        out = tmp_path / "out"
+        config = _config(sample_geoparquet_4326, out)
+        ctx = pipeline.build_context(config)
+        with pytest.raises(ValueError, match="Cannot determine temporal extent"):
+            pipeline.run_pipeline(ctx, ["masks"])
+        assert not out.exists()
+
+
+class TestStageInputErrors:
+    """Standalone stages should error clearly when inputs are missing."""
+
+    def test_chips_requires_reprojected_fields(
+        self, sample_geoparquet_4326: Path, tmp_path: Path
+    ) -> None:
+        config = _config(sample_geoparquet_4326, tmp_path / "out", year=2023)
+        ctx = pipeline.build_context(config)
+        ctx.output_dir.mkdir(parents=True)
+        with pytest.raises(StageInputError, match="reproject"):
+            pipeline.stage_chips(ctx)
+
+    def test_masks_requires_chips(self, sample_geoparquet_4326: Path, tmp_path: Path) -> None:
+        config = _config(sample_geoparquet_4326, tmp_path / "out", year=2023)
+        ctx = pipeline.build_context(config)
+        ctx.output_dir.mkdir(parents=True)
+        with pytest.raises(StageInputError, match="chips"):
+            pipeline.stage_masks(ctx)
+
+
+class TestReprojectStage:
+    """Tests for the reproject stage (no network required)."""
+
+    def test_copies_4326_input(self, sample_geoparquet_4326: Path, tmp_path: Path) -> None:
+        config = _config(sample_geoparquet_4326, tmp_path / "out", year=2023)
+        ctx = pipeline.build_context(config)
+        ctx.output_dir.mkdir(parents=True)
+        pipeline.stage_reproject(ctx)
+        assert ctx.output_fields_path.exists()
+        assert ctx.was_reprojected is False
+
+    def test_skip_reproject_errors_on_non_4326(
+        self, sample_geoparquet_3035: Path, tmp_path: Path
+    ) -> None:
+        config = _config(sample_geoparquet_3035, tmp_path / "out", year=2023, skip_reproject=True)
+        ctx = pipeline.build_context(config)
+        ctx.output_dir.mkdir(parents=True)
+        with pytest.raises(ValueError, match="EPSG:4326 is required"):
+            pipeline.stage_reproject(ctx)
+
+
+class TestRunPipelineProvenance:
+    """End-to-end (no network): run only the reproject stage via run_pipeline."""
+
+    def test_writes_provenance_and_runs_reproject(
+        self, sample_geoparquet_4326: Path, tmp_path: Path
+    ) -> None:
+        out = tmp_path / "out"
+        config = _config(sample_geoparquet_4326, out, name="ds", year=2023)
+        provenance = config.provenance_dict()
+        ctx = pipeline.build_context(config, provenance=provenance)
+        pipeline.run_pipeline(ctx, ["reproject"])
+
+        assert ctx.output_fields_path.exists()
+        prov_file = ctx.output_dir / "ftwd-config.resolved.yaml"
+        assert prov_file.exists()

--- a/tests/test_cli/test_run.py
+++ b/tests/test_cli/test_run.py
@@ -1,0 +1,87 @@
+"""CLI tests for the ftwd run command."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+from click.testing import CliRunner
+
+from ftw_dataset_tools.commands.run import run
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_config(path: Path, fields_file: Path, **overrides: object) -> Path:
+    data: dict = {
+        "fields_file": str(fields_file),
+        "year": 2023,
+        "stages": {"splits": {"split_type": "random-uniform"}},
+    }
+    data.update(overrides)  # type: ignore[arg-type]
+    path.write_text(yaml.safe_dump(data))
+    return path
+
+
+class TestRunCommand:
+    def test_help(self) -> None:
+        result = CliRunner().invoke(run, ["--help"])
+        assert result.exit_code == 0
+        assert "config-driven" in result.output or "config file" in result.output
+
+    def test_list_stages(self, sample_geoparquet_4326: Path, tmp_path: Path) -> None:
+        config_path = _write_config(tmp_path / "c.yaml", sample_geoparquet_4326)
+        result = CliRunner().invoke(run, [str(config_path), "--list-stages"])
+        assert result.exit_code == 0
+        assert "reproject" in result.output
+        assert "download_images" in result.output
+
+    def test_dry_run_shows_resolved_config_and_stages(
+        self, sample_geoparquet_4326: Path, tmp_path: Path
+    ) -> None:
+        config_path = _write_config(tmp_path / "c.yaml", sample_geoparquet_4326)
+        result = CliRunner().invoke(run, [str(config_path), "--dry-run"])
+        assert result.exit_code == 0
+        assert "Config (resolved):" in result.output
+        assert "Stages that would run:" in result.output
+        assert "reproject" in result.output
+        # download_images disabled by default -> not in the run list
+        assert "select_images" in result.output
+
+    def test_missing_config_file(self, tmp_path: Path) -> None:
+        result = CliRunner().invoke(run, [str(tmp_path / "nope.yaml")])
+        assert result.exit_code != 0
+
+    def test_invalid_config_reports_error(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "bad.yaml"
+        config_path.write_text(yaml.safe_dump({"fields_file": "f.parquet", "bogus": 1}))
+        result = CliRunner().invoke(run, [str(config_path), "--dry-run"])
+        assert result.exit_code != 0
+        assert "Unknown key" in result.output
+
+    def test_only_conflicts_with_from(self, sample_geoparquet_4326: Path, tmp_path: Path) -> None:
+        config_path = _write_config(tmp_path / "c.yaml", sample_geoparquet_4326)
+        result = CliRunner().invoke(run, [str(config_path), "--only", "masks", "--from", "chips"])
+        assert result.exit_code != 0
+        assert "cannot be combined" in result.output
+
+    def test_unknown_stage_reports_error(
+        self, sample_geoparquet_4326: Path, tmp_path: Path
+    ) -> None:
+        config_path = _write_config(tmp_path / "c.yaml", sample_geoparquet_4326)
+        result = CliRunner().invoke(run, [str(config_path), "--only", "bogus"])
+        assert result.exit_code != 0
+        assert "Unknown stage" in result.output
+
+    def test_run_through_reproject_writes_provenance(
+        self, sample_geoparquet_4326: Path, tmp_path: Path
+    ) -> None:
+        out = tmp_path / "out"
+        config_path = _write_config(
+            tmp_path / "c.yaml", sample_geoparquet_4326, output_dir=str(out), name="ds"
+        )
+        result = CliRunner().invoke(run, [str(config_path), "--through", "reproject"])
+        assert result.exit_code == 0, result.output
+        assert (out / "ds_fields.parquet").exists()
+        assert (out / "ftwd-config.resolved.yaml").exists()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `ftwd run` command for YAML-configured dataset workflows.
  * Supports dry runs, stage listing, running specific stages, and selecting stage ranges.
  * Added configurable pipeline stages for reprojection, chips, splits, masks, STAC catalogs, and imagery.
  * Resolved configuration is saved with outputs and embedded in the root catalog for traceability.
  * Added an example YAML configuration.

* **Documentation**
  * Documented configuration options, stage order, reruns, and command usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->